### PR TITLE
Allow searching for strings as well as regexps

### DIFF
--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -37,19 +37,34 @@ class PalletJack
     when options[:with_all]
       @pallets[kind].each do |name, pallet|
         result << pallet if options[:with_all].all? do |key, value|
-          pallet[key] =~ value
+          case value
+            when Regexp
+              pallet[key] =~ value
+            else
+              pallet[key].to_s == value.to_s
+          end
         end
       end
     when options[:with_any]
       @pallets[kind].each do |name, pallet|
         result << pallet if options[:with_any].any? do |key, value|
-          pallet[key] =~ value
+          case value
+            when Regexp
+              pallet[key] =~ value
+            else
+              pallet[key].to_s == value.to_s
+          end
         end
       end
     when options[:with_none]
       @pallets[kind].each do |name, pallet|
         result << pallet if options[:with_none].none? do |key, value|
-          pallet[key] =~ value
+          case value
+            when Regexp
+              pallet[key] =~ value
+            else
+              pallet[key].to_s == value.to_s
+          end
         end
       end
     when options[:name]


### PR DESCRIPTION
Currently, the search methods expect their arguments to be regexps. Trying to
search for strings gives the following error message:

  TypeError: type mismatch: String given
          from palletjack/lib/palletjack.rb:46:in `=~'

Change the search methods to look at the type of their argument, using =~ for
regexps and == for strings.

Ruby is still not my best friend, but this way of doing things is allowed by
The Book and recommended by Stack Overflow, so I assume it's not horrible.
