### PR TITLE
Document transforms, fix weirdness with multiple transforms

### DIFF
--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -11,6 +11,41 @@ class PalletJack
         value.join(param) if value
       end
 
+      # Synthesize a pallet value by pasting others together.
+      #
+      # :call-seq:
+      #   synthesize(nil, param)   -> string or nil
+      #   synthesize(value, param) -> nil
+      #
+      # If +value+ is given, an earlier transform has already produced
+      # a value for this key, so do nothing and return +nil+.
+      #
+      # Otherwise, use the parsed YAML structure in +param+ to build
+      # and return a new value. If any failure occurs while building
+      # the new value, return +nil+ to let another transform try.
+      #
+      # YAML structure:
+      #
+      #   synthesize:
+      #     - "rule"
+      #     - "rule"
+      #     ...
+      #
+      # Rules are strings used to build the new value. The value of
+      # another key is inserted by <tt>#[key]</tt>, and all other
+      # characters are copied verbatim.
+      #
+      # Rules are evaluated in order, and the first one to
+      # successfully produce a value without failing a key lookup is
+      # used.
+      #
+      # Example:
+      #
+      #   - chassis.nic.name:
+      #      synthesize:
+      #        - "p#[chassis.nic.pcislot]p#[chassis.nic.port]"
+      #        - "em#[chassis.nic.port]"
+
       def synthesize(value, param, result=String.new)
         return if value
 

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -26,6 +26,10 @@ class PalletJack
       #
       # YAML structure:
       #
+      #   - synthesize: "rule"
+      #
+      # or
+      #
       #   - synthesize:
       #     - "rule"
       #     - "rule"
@@ -40,6 +44,9 @@ class PalletJack
       # used.
       #
       # Example:
+      #
+      #   - net.dns.fqdn:
+      #     - synthesize: "#[net.ip.name].#[domain.name]"
       #
       #   - chassis.nic.name:
       #     - synthesize:

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -156,17 +156,36 @@ class PalletJack
         return product
       end
     end
-    
+
     def initialize(key_transforms={})
       @key_transforms = key_transforms
     end
-    
+
+    # Destructively transform the values in +pallet+ according to the
+    # loaded transform rules.
+    #
+    # YAML structure:
+    #
+    #   - key:
+    #     transform1:
+    #       [transform-specific configuration]
+    #     transform2:
+    #       [transform-specific configuration]
+    #     [...]
+    #
+    # Transforms are evaluated in random order, and the last one to
+    # successfully produce a value is used. Only one instance of each
+    # transform is allowed.
+    #
+    # Transforms are methods in PalletJack::KeyTransformer::Writer,
+    # called by name.
+
     def transform!(pallet)
       @pallet = pallet
       @key_transforms.each do |keytrans_item|
         key, transforms = keytrans_item.flatten
         value = @pallet[key, shallow: true]
-        
+
         transforms.each do |transform, param|
           if self.respond_to?(transform.to_sym) then
             if new_value = self.send(transform.to_sym, value, param) then


### PR DESCRIPTION
I wanted to add some documentation, and started with the key transformation system, since I had already worked there. The first commit in this series is a straight documentation of `synthesize`.

However, when I then went to document `transform!`, things quickly turned very weird. Now that there are several kinds of transforms, using more than one gave random results.

The second commit is a documentation of my understanding of what the code actually does. The third commit changes both code and documentation to match my assumptions of what it should do, specifically that the transforms should be specified in an ordered list, with the first successful one being used.
