### PR TITLE
Make all synthesize* methods use the same internal logic for #[key] substitutions

### DIFF
--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -46,7 +46,7 @@ class PalletJack
       def synthesize_internal(param, dictionary, result=String.new)
         case param
         when String
-          rex=/#\[([a-z0-9.-_]+)\]/i
+          rex=/#\[([[:alnum:]._-]+)\]/
           if md=rex.match(param) then
             result << md.pre_match
             return unless lookup = dictionary[md[1]]

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -75,25 +75,10 @@ class PalletJack
       #       - "p#[chassis.nic.pcislot]p#[chassis.nic.port]"
       #       - "em#[chassis.nic.port]"
 
-      def synthesize(value, param, result=String.new)
+      def synthesize(value, param)
         return if value
-
-        case param
-        when String
-          rex=/#\[([a-z0-9.-_]+)\]/i
-          if md=rex.match(param) then
-            result << md.pre_match
-            return unless lookup = @pallet[md[1]]
-            result << lookup.to_s
-            synthesize(false, md.post_match, result)
-          else
-            result
-          end
-        else
-          param.reduce(false) do |found_one, alternative|
-            found_one || synthesize(false, alternative)
-          end
-        end
+        
+        synthesize_internal(param, @pallet)
       end
 
       # Synthesize a pallet value from others, using regular

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -12,6 +12,36 @@ class PalletJack
       end
 
       # Internal synthesize* helper method
+      # N.B. rdoc will not be generated, because method is private.
+      #
+      # :call-seq:
+      #   synthesize_internal(param, dictionary) -> string or nil
+      #
+      # Use the single +String+ or +Enumerable+ containing +String+
+      # in +param+ to build and return a substitution value. If any
+      # failure occurs while building the new value, return +nil+.
+      #
+      # Substitutions are made from key-value pairs in +dictionary+
+      #
+      # YAML structure:
+      #
+      #   - some_rule: "rule"
+      #
+      # or
+      #
+      #   - some_rule:
+      #     - "rule"
+      #     - "rule"
+      #     ...
+      #
+      # Rules are strings used to build the new value. The value of
+      # another key is inserted by <tt>#[key]</tt>, and all other
+      # characters are copied verbatim.
+      #
+      # Rules are evaluated in order, and the first one to
+      # successfully produce a value without failing a key lookup is
+      # used.
+      #
 
       def synthesize_internal(param, dictionary, result=String.new)
         case param

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -23,7 +23,7 @@ class PalletJack
             result << lookup.to_s
             synthesize_internal(md.post_match, dictionary, result)
           else
-            result
+            result << param
           end
         else
           param.reduce(false) do |found_one, alternative|

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -134,7 +134,7 @@ class PalletJack
       #            regexp: "^(?<network>[0-9.]+)_(?<prefix_length>[0-9]+)$"
       #        produce: "#[network]/#[prefix_length]"
 
-      def synthesize_regexp(value, param, result=String.new)
+      def synthesize_regexp(value, param)
         return if value
 
         captures = {}
@@ -152,22 +152,7 @@ class PalletJack
           end
         end
 
-        # No captures succeeded. Return nil and let another transform
-        # try.
-        return if captures.length == 0
-
-        # Making a copy of the string lets us use the destructive
-        # gsub! function later, which tells us whether the
-        # substitution succeeded
-        product = param["produce"].dup
-
-        captures.each do |name, match|
-          # If a substitution fails, return nil and let another
-          # transform try.
-          return unless product.gsub!("#[#{name}]", match)
-        end
-
-        return product
+        synthesize_internal(param["produce"], captures)
       end
     end
 

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -11,6 +11,28 @@ class PalletJack
         value.join(param) if value
       end
 
+      # Internal synthesize* helper method
+
+      def synthesize_internal(param, dictionary, result=String.new)
+        case param
+        when String
+          rex=/#\[([a-z0-9.-_]+)\]/i
+          if md=rex.match(param) then
+            result << md.pre_match
+            return unless lookup = dictionary[md[1]]
+            result << lookup.to_s
+            synthesize_internal(md.post_match, dictionary, result)
+          else
+            result
+          end
+        else
+          param.reduce(false) do |found_one, alternative|
+            found_one || synthesize_internal(alternative, dictionary)
+          end
+        end
+      end
+      private :synthesize_internal
+
       # Synthesize a pallet value by pasting others together.
       #
       # :call-seq:

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -55,7 +55,7 @@ class PalletJack
           else
             result << param
           end
-        else
+        else # Enumerable
           param.reduce(false) do |found_one, alternative|
             found_one || synthesize_internal(alternative, dictionary)
           end


### PR DESCRIPTION
The previous implementation of synthesize_regexp required that all keys found by source regexp’s were used in the single substitution string, but didn’t care about substitution attempts for nonexistent keys.

Using the same logic as used for regular synthezise makes more sense, that all substitutions in a string must succeed, with possibly a list of alternates to try.

This enables DRY regexp source definitions via references, and alternate substitutions for use with YAML structures like this:

```
- os.name:
  - synthesize_regexp:
      sources: &pallet_os
        os:
          key: "pallet.os"
          regexp: "^(?<name>[^-]*)-(?<major>[^.-]*)(\\.(?<minor>[^.-]*))?(\\.(?<micro>[^-]))?(-(?<arch>.*))?"
      produce: "#[name]"
- os.release:
  - synthesize_regexp:
      sources: *pallet_os
      produce:
        - "#[major].#[minor].#[micro]"
        - "#[major].#[minor]"
        - "#[major]"
- os.architecture:
  - syntheisize_regexp:
      sources: *pallet_os
      produce:
        - "#[arch]"
  - synthesize: "#[host.architecture]"
```
