### PR TITLE
palletjack2salt

### DIFF
--- a/palletjack-tools.gemspec
+++ b/palletjack-tools.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.files	= [ 'README.md', 'LICENSE' ]
   s.files	+= Dir['tools/*']
   s.bindir      = 'tools/'
-  s.executables	= ['dump_pallet', 'palletjack2kea']
+  s.executables	= ['dump_pallet', 'palletjack2kea', 'palletjack2salt']
   s.has_rdoc	= true
 end

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+# Return a YAML structure containing Salt external pillar data for all
+# systems.
+#
+# Intended to be run as a cmd_yaml external pillar, e.g.:
+#   ext_pillar:
+#   - cmd_yaml: '/usr/bin/palletjack2salt -w /etc/warehouse/ -m %s'
+#
+# Data model assumptions:
+# - Salt minion ID is FQDN
+# - Role list is at system.role
+# - Output structure is:
+#
+#   palletjack:
+#     role:
+#       - role1
+#       - role2
+#       ...
+
+require 'palletjack'
+require 'optparse'
+require 'yaml'
+
+options = {}
+
+opts = OptionParser.new
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse>
+
+Write Salt pillar data from a Palletjack warehouse
+
+"
+opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) {|dir| options[:warehouse] = dir }
+opts.on("-m MINION", "--minion MINION", "Salt minion ID", String) {|minion| options[:minion] = minion }
+opts.parse!
+
+if not options[:warehouse] or
+    not options[:minion]
+  puts opts.to_s
+  exit 1
+end
+
+output = { 'palletjack' => {} }
+
+jack = PalletJack.new(options[:warehouse])
+
+jack["system",
+     with_all:{'net.dns.fqdn' => options[:minion]}].each do |system|
+  output['palletjack'] = { 'role' => system['system.role'] }
+end
+
+puts output.to_yaml

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -1,11 +1,16 @@
 #!/usr/bin/env ruby
 
-# Return a YAML structure containing Salt external pillar data for all
-# systems.
+# Write YAML files containing Salt external pillar data for all
+# systems, one file per system.
 #
-# Intended to be run as a cmd_yaml external pillar, e.g.:
+# Intended to be run from a Git post-update hook or similar, writing
+# YAML files which will be read by a Salt cmd_yaml external pillar,
+# since running the entire Pallet Jack infrastructure once per minion
+# for every pillar refresh is a bit excessive. Example Salt master
+# configuration:
+#
 #   ext_pillar:
-#   - cmd_yaml: '/usr/bin/palletjack2salt -w /etc/warehouse/ -m %s'
+#     - cmd_yaml: cat /var/cache/salt/ext_pillar/%s.yaml
 #
 # Data model assumptions:
 # - Salt minion ID is FQDN
@@ -25,28 +30,26 @@ require 'yaml'
 options = {}
 
 opts = OptionParser.new
-opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse>
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -d <output directory>
 
-Write Salt pillar data from a Palletjack warehouse
+Write Salt pillar data from a Palletjack warehouse, one YAML file per system
 
 "
 opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) {|dir| options[:warehouse] = dir }
-opts.on("-m MINION", "--minion MINION", "Salt minion ID", String) {|minion| options[:minion] = minion }
+opts.on("-o DIR", "--output DIR", "output directory", String) {|dir| options[:output] = dir }
 opts.parse!
 
 if not options[:warehouse] or
-    not options[:minion]
+    not options[:output] or
+    not File.directory?(options[:output])
   puts opts.to_s
   exit 1
 end
 
-output = { 'palletjack' => {} }
-
 jack = PalletJack.new(options[:warehouse])
 
-jack["system",
-     with_all:{'net.dns.fqdn' => options[:minion]}].each do |system|
-  output['palletjack'] = { 'role' => system['system.role'] }
+jack["system"].each do |system|
+  File.open("#{options[:output]}/#{system['net.dns.fqdn']}.yaml", File::CREAT | File::TRUNC | File::WRONLY, 0644) do |yamlfile|
+    yamlfile << { 'palletjack' => { 'role' => system['system.role'] } }.to_yaml
+  end
 end
-
-puts output.to_yaml


### PR DESCRIPTION
Tool for writing YAML files, one per minion, containing Salt roles. Run this from a Git `post-update` hook or similar, and have Salt read the cached files with a trivial `ext_pilar`.

This is the same code as pull request #15, rebased onto the new master.
