### PR TITLE
Unify tool arguments

### DIFF
--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -22,7 +22,7 @@ Write PXELINUX boot configuration files from a Palletjack warehouse
 
 "
 opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) {|dir| options[:warehouse] = dir }
-opts.on("-d DIR", "--output DIR", "output directory (pxelinux.cfg)", String) {|dir| options[:output] = dir }
+opts.on("-o DIR", "--output DIR", "output directory (pxelinux.cfg)", String) {|dir| options[:output] = dir }
 opts.parse!
 
 if not options[:warehouse] or

--- a/tools/palletjack2zone
+++ b/tools/palletjack2zone
@@ -19,7 +19,7 @@ Write DNS server zone files from a Palletjack warehouse
 
 "
 opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) {|dir| options[:warehouse] = dir }
-opts.on("-d DIR", "--output DIR", "output directory", String) {|dir| options[:output] = dir }
+opts.on("-o DIR", "--output DIR", "output directory", String) {|dir| options[:output] = dir }
 opts.parse!
 
 if not options[:warehouse] or


### PR DESCRIPTION
Some tools took short option "-d" for output directory, and some took "-o".
Standardise on "-o".
