### PR TITLE
Layer 2 naming

### DIFF
--- a/examples/warehouse/phy_nic/52:54:00:12:34:56/identity.yaml
+++ b/examples/warehouse/phy_nic/52:54:00:12:34:56/identity.yaml
@@ -1,0 +1,3 @@
+net:
+  layer2:
+    name: eth0

--- a/examples/warehouse/phy_nic/README
+++ b/examples/warehouse/phy_nic/README
@@ -6,7 +6,8 @@ Type name: phy_nic
 Represents an Ethernet network interface card.
 
 The name of a NIC is its Ethernet MAC address, with bytes separated by
-":".
+":". The default transform rules copy the MAC address to
+"net.layer2.address".
 
 For a physical network interface, the link "chassis" points to the
 chassis in which that interface lives and the key "chassis.nic.port"
@@ -14,14 +15,11 @@ contains the physical port number in the chassis. For virtual
 networks, the link "phy_nic" points to the physical interface on which
 they run.
 
-This information is primarily used by "palletjack2kea" for creating
-DHCP configuration files with static leases for all interfaces which
-have IP addresses allocated.
-
 
 Files:
 
   phy_nic/<name>/location.yaml
+  phy_nic/<name>/identity.yaml
 
 
 Links:
@@ -37,3 +35,8 @@ location.yaml:
     nic:
       port: Port number, as printed on the back of the physical
             chassis
+
+identity.yaml:
+  net:
+    layer2:
+      name: Name of this interface as seen by the OS, e.g. "eth0"

--- a/examples/warehouse/transforms.yaml
+++ b/examples/warehouse/transforms.yaml
@@ -147,7 +147,7 @@
   - synthesize: "#[pallet.os]"
 - net.ipv4.address:
   - synthesize: "#[pallet.ipv4_interface]"
-- net.mac.address:
+- net.layer2.address:
   - synthesize: "#[pallet.phy_nic]"
 - host.pxelinux.config:
   - synthesize: "#[pallet.os]"
@@ -169,6 +169,14 @@
   - synthesize:
       - "p#[chassis.nic.pcislot]p#[chassis.nic.port]"
       - "em#[chassis.nic.port]"
+
+
+# This is probably a bad default, but it's at least something. If the
+# rules for "chassis.nic.name" above get expanded to include the
+# entire Linux Udev ruleset, this will work perfectly.
+
+- net.layer2.name:
+  - synthesize: "#[chassis.nic.name]"
 
 
 # Regexp synthesizing rules. ipv4_network objects are named like

--- a/tools/palletjack2kea
+++ b/tools/palletjack2kea
@@ -91,7 +91,7 @@ jack["ipv4_network"].each do |net|
        with_all:{"pallet.ipv4_network" =>
                  net['pallet.ipv4_network']}].each do |interface|
     net_config["reservations"] << {
-      "hw-address" => "#{interface['net.mac.address']}",
+      "hw-address" => "#{interface['net.layer2.address']}",
       "ip-address" => "#{interface['net.ipv4.address']}",
       "hostname" => "#{interface['net.dns.fqdn']}"
     }

--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -39,7 +39,7 @@ jack["system"].each do |system|
        with_all:{"pallet.system" =>
                  system['pallet.system']}].each do |nic|
     if system['host.pxelinux.config']
-      filename = "#{options[:output]}/01-#{nic['net.mac.address'].gsub(':', '-').downcase}"
+      filename = "#{options[:output]}/01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
       FileUtils.ln_s("#{system['host.pxelinux.config']}.menu", filename, :force => true)
     end
   end


### PR DESCRIPTION
Refactor the key hierarchy under `net.` concerning layer 2 stuff, in preparation for writing network configuration using Salt.
