### PR TITLE
Include network information in Salt pillars

### DIFF
--- a/palletjack-tools.gemspec
+++ b/palletjack-tools.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.platform	= Gem::Platform::RUBY
   s.required_ruby_version = '~>2'
   s.add_runtime_dependency 'palletjack', s.version
+  s.add_runtime_dependency 'kvdag', '~> 0.0.3'
   s.add_runtime_dependency 'dns-zone', '~> 0.3'
   s.add_runtime_dependency 'ruby-ip', '~> 0.9'
   s.files	= [ 'README.md', 'LICENSE' ]

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -52,8 +52,10 @@ jack['system'].each do |system|
   yaml_output = { 'ipv4_interfaces' => {} }
   jack['ipv4_interface', with_all:{'pallet.system' =>
       system['system.name']}].each do |interface|
-    yaml_output['ipv4_interfaces'][interface['net.layer2.name']] =
+    yaml_output['ipv4_interfaces'][interface['net.layer2.name']] = {
+      interface['net.ipv4.address'] =>
       interface.filter('net.ipv4', 'net.layer2').to_hash
+    }
   end
 
   yaml_output['system'] = system['system']

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -48,8 +48,17 @@ end
 
 jack = PalletJack.new(options[:warehouse])
 
-jack["system"].each do |system|
+jack['system'].each do |system|
+  yaml_output = { 'ipv4_interfaces' => {} }
+  jack['ipv4_interface', with_all:{'pallet.system' =>
+      system['system.name']}].each do |interface|
+    yaml_output['ipv4_interfaces'][interface['net.layer2.name']] =
+      interface.filter('net.ipv4', 'net.layer2').to_hash
+  end
+
+  yaml_output['system'] = system['system']
+
   File.open("#{options[:output]}/#{system['net.dns.fqdn']}.yaml", File::CREAT | File::TRUNC | File::WRONLY, 0644) do |yamlfile|
-    yamlfile << { 'palletjack' => { 'role' => system['system.role'] } }.to_yaml
+    yamlfile << { 'palletjack' => yaml_output }.to_yaml
   end
 end


### PR DESCRIPTION
Salt needs more information about systems than just their roles. At least
network configuration is required, so include that as a proof of concept.

This requires the pallet.filter functionality in Keyvaluedag 0.0.3.
