### PR TITLE
Warehouse creation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,62 @@ kvmguest1
 kvmguest1
  => #<Set: {#<PalletJack::Pallet:10775a0>}> 
 ```
+
+## Creating warehouse objects
+
+Warehouse objects are simple directories, so you can create them using
+`mkdir`. To simplify the process, there are some tools that create
+objects with standard links and YAML structures for you. Example:
+
+```bash
+$ create_domain -w /tmp/warehouse -d example.com -n 192.168.42.0/24
+$ create_system -w /tmp/warehouse -s vmhost -d example.com -o CentOS-7.2.1511-x86_64
+$ create_ipv4_interface -w /tmp/warehouse -s vmhost -d example.com -m 52:54:00:8d:be:fe -i 192.168.42.1 -n 192.168.42.0/24
+$ dump_pallet -w /tmp/warehouse -t ipv4_interface
+```
+```yaml
+---
+pallet:
+  ipv4_network: 192.168.42.0_24
+  boxes: []
+  references:
+    ipv4_network: 192.168.42.0_24
+    domain: example.com
+    phy_nic: 52:54:00:8d:be:fe
+    os: CentOS-7.2.1511-x86_64
+    system: vmhost
+  domain: example.com
+  phy_nic: 52:54:00:8d:be:fe
+  os: CentOS-7.2.1511-x86_64
+  system: vmhost
+  ipv4_interface: 192.168.42.1
+net:
+  dhcp:
+    tftp-server: ''
+    boot-file: ''
+  ipv4:
+    gateway: ''
+    prefixlen: '24'
+    cidr: 192.168.42.0/24
+    address: 192.168.42.1
+  dns:
+    resolver: ''
+    ns:
+    - ''
+    domain: example.com
+    name: vmhost
+    fqdn: vmhost.example.com
+  soa-ns: ''
+  soa-contact: ''
+  layer2:
+    name: ''
+    address: 52:54:00:8d:be:fe
+system:
+  os: CentOS-7.2.1511-x86_64
+  role:
+  - ''
+  name: vmhost
+host:
+  pxelinux:
+    config: CentOS-7.2.1511-x86_64
+```

--- a/palletjack-tools.gemspec
+++ b/palletjack-tools.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.files	= [ 'README.md', 'LICENSE' ]
   s.files	+= Dir['tools/*']
   s.bindir      = 'tools/'
-  s.executables	= ['dump_pallet', 'palletjack2kea', 'palletjack2salt', 'palletjack2pxelinux']
+  s.executables = ['dump_pallet', 'palletjack2kea', 'palletjack2salt',
+    'palletjack2pxelinux', 'create_domain', 'create_system',
+    'create_ipv4_interface']
   s.has_rdoc	= true
 end

--- a/tools/create_domain
+++ b/tools/create_domain
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+
+# Create a domain and IPv4 network in a warehouse
+#
+# Data model assumptions:
+# - Each domain corresponds uniquely to one IPv4 network
+
+require 'palletjack'
+require 'optparse'
+
+$options = {}
+
+opts = OptionParser.new
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -d <domain> -n <IPv4 network>
+
+Create domain and ipv4_network objects in a warehouse
+
+"
+opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) { |dir| $options[:warehouse] = dir }
+opts.on("-d DOMAIN", "--domain DOMAIN", "domain name", String) { |domain| $options[:domain] = domain }
+opts.on("-n NETWORK", "--network NETWORK", "IPv4 network, in CIDR format", String) { |network|
+         $options[:network] = network.gsub(/\//, '_')
+       }
+opts.parse!
+
+if not $options[:warehouse] or
+    not $options[:domain] or
+    not $options[:network] or
+    not File.directory?($options[:warehouse])
+  puts opts.to_s
+  exit 1
+end
+
+def exists_ok(&code)
+  code.call()
+rescue Errno::EEXIST
+  nil
+end
+
+def warehouse_symlink(target, source)
+  begin
+    File.delete("#{$options[:warehouse]}/#{source}")
+  rescue Errno::ENOENT
+    nil
+  end
+
+  File.symlink("../../#{target}", "#{$options[:warehouse]}/#{source}")
+end
+
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/domain/") }
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/domain/#{$options[:domain]}") }
+
+File.open("#{$options[:warehouse]}/domain/#{$options[:domain]}/dns.yaml",
+          File::CREAT | File::TRUNC | File::WRONLY, 0644) do |dns_file|
+  dns_file << { 'net' => { 'dns' => { 'ns' => [ '' ] },
+                           'soa-ns' => '',
+                           'soa-contact' => '' } }.to_yaml
+end
+
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/ipv4_network/") }
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/ipv4_network/#{$options[:network]}") }
+warehouse_symlink("ipv4_network/#{$options[:network]}/",
+                  "domain/#{$options[:domain]}/ipv4_network")
+
+File.open("#{$options[:warehouse]}/ipv4_network/#{$options[:network]}/dhcp.yaml",
+          File::CREAT | File::TRUNC | File::WRONLY, 0644) do |dhcp_file|
+  dhcp_file << { 'net' => { 'dhcp' => { 'tftp-server' => '', 'boot-file' => '' } } }.to_yaml
+end
+
+File.open("#{$options[:warehouse]}/ipv4_network/#{$options[:network]}/identity.yaml",
+          File::CREAT | File::TRUNC | File::WRONLY, 0644) do |identity_file|
+  identity_file << { 'net' => { 'ipv4' => { 'gateway' => '' },
+                                'dns' => { 'resolver' => '' } } }.to_yaml
+end

--- a/tools/create_ipv4_interface
+++ b/tools/create_ipv4_interface
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+
+# Create a physical and logical IPv4 network interface in a warehouse
+
+require 'palletjack'
+require 'optparse'
+
+$options = {}
+
+opts = OptionParser.new
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -s <system> -d <domain> -m <MAC address> -i <IPv4 address> -n <IPv4 network>
+
+Create phy_nic and ipv4_interface objects in a warehouse
+
+"
+opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) { |dir| $options[:warehouse] = dir }
+opts.on("-s SYSTEM", "--system SYSTEM", "system name", String) { |system| $options[:system] = system }
+opts.on("-d DOMAIN", "--domain DOMAIN", "domain name", String) { |domain| $options[:domain] = domain }
+opts.on("-m MAC", "--mac MAC", "MAC address", String) { |mac| $options[:mac] = mac }
+opts.on("-i ADDR", "--ipv4 ADDR", "IPv4 address", String) { |addr| $options[:addr] = addr }
+opts.on("-n NETWORK", "--network NETWORK", "IPv4 network, in CIDR format", String) { |network|
+         $options[:network] = network.gsub(/\//, '_')
+       }
+opts.parse!
+
+if not $options[:warehouse] or
+    not $options[:system] or
+    not $options[:domain] or
+    not $options[:mac] or
+    not $options[:addr] or
+    not $options[:network] or
+    not File.directory?($options[:warehouse])
+  puts opts.to_s
+  exit 1
+end
+
+def exists_ok(&code)
+  code.call()
+rescue Errno::EEXIST
+  nil
+end
+
+def warehouse_symlink(target, source)
+  begin
+    File.delete("#{$options[:warehouse]}/#{source}")
+  rescue Errno::ENOENT
+    nil
+  end
+
+  File.symlink("../../#{target}", "#{$options[:warehouse]}/#{source}")
+end
+
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/phy_nic/") }
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/phy_nic/#{$options[:mac]}") }
+
+File.open("#{$options[:warehouse]}/phy_nic/#{$options[:mac]}/identity.yaml",
+          File::CREAT | File::TRUNC | File::WRONLY, 0644) do |identity_file|
+  identity_file << { 'net' => { 'layer2' => { 'name' => '' } } }.to_yaml
+end
+
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/ipv4_interface/") }
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/ipv4_interface/#{$options[:addr]}") }
+warehouse_symlink("ipv4_network/#{$options[:network]}/",
+                  "ipv4_interface/#{$options[:addr]}/ipv4_network")
+warehouse_symlink("domain/#{$options[:domain]}/",
+                  "ipv4_interface/#{$options[:addr]}/domain")
+warehouse_symlink("phy_nic/#{$options[:mac]}/",
+                  "ipv4_interface/#{$options[:addr]}/phy_nic")
+warehouse_symlink("system/#{$options[:system]}/",
+                  "ipv4_interface/#{$options[:addr]}/system")

--- a/tools/create_system
+++ b/tools/create_system
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+# Create a system in a warehouse
+
+require 'palletjack'
+require 'optparse'
+
+$options = {}
+
+opts = OptionParser.new
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -s <system> -d <domain> -o <os>
+
+Create system objects in a warehouse
+
+"
+opts.on("-w DIR", "--warehouse DIR", "warehouse directory", String) { |dir| $options[:warehouse] = dir }
+opts.on("-s SYSTEM", "--system SYSTEM", "system name", String) { |system| $options[:system] = system }
+opts.on("-d DOMAIN", "--domain DOMAIN", "domain name", String) { |domain| $options[:domain] = domain }
+opts.on("-o OS", "--os OS", "operating system name", String) { |os| $options[:os] = os }
+opts.parse!
+
+if not $options[:warehouse] or
+    not $options[:system] or
+    not $options[:domain] or
+    not $options[:os] or
+    not File.directory?($options[:warehouse])
+  puts opts.to_s
+  exit 1
+end
+
+def exists_ok(&code)
+  code.call()
+rescue Errno::EEXIST
+  nil
+end
+
+def warehouse_symlink(target, source)
+  begin
+    File.delete("#{$options[:warehouse]}/#{source}")
+  rescue Errno::ENOENT
+    nil
+  end
+
+  File.symlink("../../#{target}", "#{$options[:warehouse]}/#{source}")
+end
+
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/system/") }
+exists_ok { Dir.mkdir("#{$options[:warehouse]}/system/#{$options[:system]}") }
+
+File.open("#{$options[:warehouse]}/system/#{$options[:system]}/role.yaml",
+          File::CREAT | File::TRUNC | File::WRONLY, 0644) do |dns_file|
+  dns_file << { 'system' => { 'role' => [ '' ] } }.to_yaml
+end
+
+warehouse_symlink("domain/#{$options[:domain]}/",
+                  "system/#{$options[:system]}/domain")
+warehouse_symlink("os/#{$options[:os]}/",
+                  "system/#{$options[:system]}/os")


### PR DESCRIPTION
To simplify the construction of lab warehouses, implement tools "create_domain", "create_system" and "create_ipv4_interface" which add standard file and YAML structures with empty values.

Closes #32.
