### PR TITLE
Move PXELINUX configuration to subdirectories

### DIFF
--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -27,9 +27,8 @@
 #      |   ...
 #      ...
 #
-# Point this script's output directory at
-# /var/lib/tftpboot/pxelinux.cfg/, and it will create the MAC address
-# symlinks.
+# Point this script's output directory at /var/lib/tftpboot/, and it
+# will create the MAC address symlinks.
 
 require 'palletjack'
 require 'optparse'
@@ -61,7 +60,7 @@ jack["system"].each do |system|
        with_all:{"pallet.system" =>
                  system['pallet.system']}].each do |nic|
     if system['host.pxelinux.config']
-      filename = "#{options[:output]}/01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
+      filename = "#{options[:output]}/pxelinux.cfg/01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
       FileUtils.ln_s("../config/#{system['host.pxelinux.config']}.menu", filename, :force => true)
     end
   end

--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -5,9 +5,31 @@
 # Data model assumptions:
 #
 # Each OS has a box containing the key "host.pxelinux.configfile",
-# whose value is a string containing the path to the PXELINUX
-# configuration file which installs that OS, relative to the
-# pxelinux.cfg/ directory.
+# whose value is a string containing a partial file name for a
+# PXELINUX configuration file which installs that OS, in the
+# /var/lib/tftpboot/config/ directory, without the ".menu" suffix.
+#
+# PXELINUX directory tree:
+#
+# /var/lib/tftpboot/
+#  |- pxelinux.cfg
+#  |   |- default -> ../config/default
+#  |   |- 01-<MAC address> -> ../config/<OS>.menu
+#  |   ...
+#  |- config
+#  |   |- default
+#  |   |- <OS>.menu
+#  |   ...
+#  \- boot
+#      |- <OS>
+#      |   |- vmlinuz
+#      |   |- initrd
+#      |   ...
+#      ...
+#
+# Point this script's output directory at
+# /var/lib/tftpboot/pxelinux.cfg/, and it will create the MAC address
+# symlinks.
 
 require 'palletjack'
 require 'optparse'
@@ -40,7 +62,7 @@ jack["system"].each do |system|
                  system['pallet.system']}].each do |nic|
     if system['host.pxelinux.config']
       filename = "#{options[:output]}/01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
-      FileUtils.ln_s("#{system['host.pxelinux.config']}.menu", filename, :force => true)
+      FileUtils.ln_s("../config/#{system['host.pxelinux.config']}.menu", filename, :force => true)
     end
   end
 end


### PR DESCRIPTION
Keeping both configuration and MAC address symlinks in the same directory is
confusing, and makes Salt automation harder. Keep symlinks in /pxelinux.cfg/
and actual configuration in /config/.
