### PR TITLE
Make net.dns.resolver a list of resolvers

### DIFF
--- a/tools/create_domain
+++ b/tools/create_domain
@@ -70,5 +70,5 @@ end
 File.open("#{$options[:warehouse]}/ipv4_network/#{$options[:network]}/identity.yaml",
           File::CREAT | File::TRUNC | File::WRONLY, 0644) do |identity_file|
   identity_file << { 'net' => { 'ipv4' => { 'gateway' => '' },
-                                'dns' => { 'resolver' => '' } } }.to_yaml
+                                'dns' => { 'resolver' => [ '' ] } } }.to_yaml
 end


### PR DESCRIPTION
There can be many DNS resolvers, so the property needs to be a list of resolvers, and not just a single resolver.
