### PR TITLE
Fix create_domain generated structure for domain objects

### DIFF
--- a/tools/create_domain
+++ b/tools/create_domain
@@ -52,9 +52,9 @@ exists_ok { Dir.mkdir("#{$options[:warehouse]}/domain/#{$options[:domain]}") }
 
 File.open("#{$options[:warehouse]}/domain/#{$options[:domain]}/dns.yaml",
           File::CREAT | File::TRUNC | File::WRONLY, 0644) do |dns_file|
-  dns_file << { 'net' => { 'dns' => { 'ns' => [ '' ] },
-                           'soa-ns' => '',
-                           'soa-contact' => '' } }.to_yaml
+  dns_file << { 'net' => { 'dns' => { 'ns' => [ '' ],
+                                      'soa-ns' => '',
+                                      'soa-contact' => '' } } }.to_yaml
 end
 
 exists_ok { Dir.mkdir("#{$options[:warehouse]}/ipv4_network/") }


### PR DESCRIPTION
The generated template for a domain object had an incorrect structure,
where soa-\* attributes were generated at `net` instead of `net.dns`.

This fixes #40.
