### PR TITLE
Tag keys to be inherited before synthesis, fixes #31

### DIFF
--- a/examples/warehouse/transforms.yaml
+++ b/examples/warehouse/transforms.yaml
@@ -31,7 +31,7 @@
 #
 # The synthesized value will override an inherited value for a key,
 # but in some cases the intent is actually to only synthesize a value
-# when there is no inherited value. For this we have the "inherited"
+# when there is no inherited value. For this we have the "inherit"
 # transform, that does nothing, except abort the transform chain for a
 # key if there is an inherited value.
 #
@@ -115,12 +115,12 @@
 #        produce: "#[network]/#[prefix_length]"
 #
 #
-# inherited
+# inherit
 # ---------
 #
 # YAML structure:
 #
-#   - inherited: ~
+#   - inherit: ~
 #
 # Declares that the key is to be inherited first. By default,
 # synthesis rules shadows inherited values for a key.
@@ -134,7 +134,7 @@
 # instead of a physical phy_nic.
 #
 #  - net.layer2.name:
-#    - inherited: ~
+#    - inherit: ~
 #    - synthesize: "#[chassis.nic.name]"
 
 
@@ -209,7 +209,7 @@
 # overridden by the physical chassis based name.
 
 - net.layer2.name:
-  - inherited: ~
+  - inherit: ~
   - synthesize: "#[chassis.nic.name]"
 
 

--- a/examples/warehouse/transforms.yaml
+++ b/examples/warehouse/transforms.yaml
@@ -29,6 +29,12 @@
 # Two synthesizing rules are currently defined: "synthesize" and
 # "synthesize_regexp".
 #
+# The synthesized value will override an inherited value for a key,
+# but in some cases the intent is actually to only synthesize a value
+# when there is no inherited value. For this we have the "inherited"
+# transform, that does nothing, except abort the transform chain for a
+# key if there is an inherited value.
+#
 #
 # synthesize
 # ----------
@@ -107,6 +113,29 @@
 #            key: "pallet.ipv4_network"
 #            regexp: "^(?<network>[0-9.]+)_(?<prefix_length>[0-9]+)$"
 #        produce: "#[network]/#[prefix_length]"
+#
+#
+# inherited
+# ---------
+#
+# YAML structure:
+#
+#   - inherited: ~
+#
+# Declares that the key is to be inherited first. By default,
+# synthesis rules shadows inherited values for a key.
+#
+# Any parameters are currently ignored, but should be ~ (nil).
+#
+# Example:
+#
+# Don't synthesize net.layer2.name when there is an inherited value,
+# e.g. for ipv4_interface, that inherits from a virtual phy_nic
+# instead of a physical phy_nic.
+#
+#  - net.layer2.name:
+#    - inherited: ~
+#    - synthesize: "#[chassis.nic.name]"
 
 
 # Default transforms
@@ -175,11 +204,9 @@
 # rules for "chassis.nic.name" above get expanded to include the
 # entire Linux Udev ruleset, this will work perfectly.
 #
-# Synthesized value will override an inherited value for a key, but in
-# some cases the intent is actually to only synthesize a value when
-# there is no inherited value. For this we have the `inherited`
-# transform, that does nothing, except abort the transform chain for a
-# key if there is an inherited value.
+# A phy_nic can be either physical or virtual. Ensure that any
+# assigned value for a virtual phy_nic is inherited, and not
+# overridden by the physical chassis based name.
 
 - net.layer2.name:
   - inherited: ~

--- a/examples/warehouse/transforms.yaml
+++ b/examples/warehouse/transforms.yaml
@@ -174,8 +174,15 @@
 # This is probably a bad default, but it's at least something. If the
 # rules for "chassis.nic.name" above get expanded to include the
 # entire Linux Udev ruleset, this will work perfectly.
+#
+# Synthesized value will override an inherited value for a key, but in
+# some cases the intent is actually to only synthesize a value when
+# there is no inherited value. For this we have the `inherited`
+# transform, that does nothing, except abort the transform chain for a
+# key if there is an inherited value.
 
 - net.layer2.name:
+  - inherited: ~
   - synthesize: "#[chassis.nic.name]"
 
 

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -211,20 +211,23 @@ class PalletJack
 
     def transform!(pallet)
       @key_transforms.each do |keytrans_item|
-        key, transforms = keytrans_item.flatten
-        context = {
-          pallet: pallet,
-          key:    key,
-          value:  pallet[key, shallow: true],
-        }
+        catch do |abort_tag|
+          key, transforms = keytrans_item.flatten
+          context = {
+            pallet: pallet,
+            key:    key,
+            value:  pallet[key, shallow: true],
+            abort:  abort_tag
+          }
 
-        transforms.each do |t|
-          transform, param = t.flatten
-          if self.respond_to?(transform.to_sym) then
-            if new_value = self.send(transform.to_sym, param, context)
-            then
-              pallet[key] = new_value
-              break
+          transforms.each do |t|
+            transform, param = t.flatten
+            if self.respond_to?(transform.to_sym) then
+              if new_value = self.send(transform.to_sym, param, context)
+              then
+                pallet[key] = new_value
+                break
+              end
             end
           end
         end

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -184,6 +184,21 @@ class PalletJack
 
         synthesize_internal(param["produce"], captures)
       end
+
+      # Synthesized value will override an inherited value for a
+      # +key+, but in some cases the intent is actually to only
+      # synthesize a value when there is no inherited value. This
+      # provides early termination of transforms for such keys.
+      #
+      # Example:
+      #
+      #  - net.layer2.name:
+      #    - inherited: ~
+      #    - synthesize: "#[chassis.nic.name]"
+
+      def inherited(_, context = {})
+        throw context[:abort] if context[:pallet][context[:key]]
+      end
     end
 
     def initialize(key_transforms={})

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -223,9 +223,20 @@ class PalletJack
     # Transforms are methods in PalletJack::KeyTransformer::Writer,
     # called by name. They should return the new value, or +false+ if
     # unsuccessful.
+    #
+    # Transforms are given two parameters, +param+ and +context+:
+    # [+param+]     transform-specific configuration from transforms.yaml
+    # [+context+]
+    #    [+pallet+] The pallet object being processed
+    #    [+key+]    The key from transforms.yaml being processed
+    #    [+value+]  Current locally assigned value for key in pallet
+    #    [+abort+]  #throw this to abort transforms for current key
 
     def transform!(pallet)
       @key_transforms.each do |keytrans_item|
+
+        # Enable early termination of transforms for a key
+        # by wrapping execution in a catch block.
         catch do |abort_tag|
           key, transforms = keytrans_item.flatten
           context = {

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -193,10 +193,10 @@ class PalletJack
       # Example:
       #
       #  - net.layer2.name:
-      #    - inherited: ~
+      #    - inherit: ~
       #    - synthesize: "#[chassis.nic.name]"
 
-      def inherited(_, context = {})
+      def inherit(_, context = {})
         throw context[:abort] if context[:pallet][context[:key]]
       end
     end


### PR DESCRIPTION
By design, a synthesized value will override an inherited value for a `key`, but in some cases the intent is actually to only synthesize a value when there is no inherited value. This provides early termination of transforms for such keys.

Example:

``` yaml
- net.layer2.name:
  - inherited: ~
  - synthesize: "#[chassis.nic.name]"
```
