### PR TITLE
Configure central Syslog archive

### DIFF
--- a/examples/warehouse/domain/README
+++ b/examples/warehouse/domain/README
@@ -8,18 +8,22 @@ Represents a DNS domain.
 The link "ipv4_network" points to the IPv4 network corresponding to
 this DNS domain.
 
-This information is used by the tools "palletjack2kea", to write the
-domain name in the DHCP configuration, and "palletjack2zone", to write
-zone files for a DNS server. If the ipv4_network link points to a
-network which has its netblock in CIDR form in the key
-"net.ipv4.cidr", and the netmask length is a whole number of octets
-(i.e. 0, 8, 16 or 24 bits), "palletjack2zone" will also write reverse
-zones for all defined IP addresses.
+The information in "dns.yaml" is used by the tools "palletjack2kea",
+to write the domain name in the DHCP configuration, and
+"palletjack2zone", to write zone files for a DNS server. If the
+ipv4_network link points to a network which has its netblock in CIDR
+form in the key "net.ipv4.cidr", and the netmask length is a whole
+number of octets (i.e. 0, 8, 16 or 24 bits), "palletjack2zone" will
+also write reverse zones for all defined IP addresses.
+
+The information in "services.yaml" is used by "palletjack2salt" to
+write Salt pillar data pointing to services available in the domain.
 
 
 Files:
 
   domain/<name>/dns.yaml
+  domain/<name>/services.yaml
 
 
 Links:
@@ -40,4 +44,11 @@ dns.yaml:
           ...
       ns:
         - IP address of NS server authoritative for this domain
+        - ...
+
+services.yaml:
+  domain:
+    services:
+      syslog:
+        - A central Syslog server, in the form <fqdn>:<port>
         - ...

--- a/examples/warehouse/domain/README
+++ b/examples/warehouse/domain/README
@@ -47,8 +47,10 @@ dns.yaml:
         - ...
 
 services.yaml:
-  domain:
-    services:
+  net:
+    service:
       syslog:
-        - A central Syslog server, in the form <fqdn>:<port>
+        - address: FQDN of central syslog server
+          port: Port to talk to on central syslog server
+          protocol: "tcp" or "udp"
         - ...

--- a/examples/warehouse/domain/example.com/services.yaml
+++ b/examples/warehouse/domain/example.com/services.yaml
@@ -1,0 +1,5 @@
+domain:
+  services:
+    syslog:
+      - syslog-archive.example.com:514
+      - logstash.example.com:5514

--- a/examples/warehouse/domain/example.com/services.yaml
+++ b/examples/warehouse/domain/example.com/services.yaml
@@ -1,5 +1,9 @@
-domain:
-  services:
+net:
+  service:
     syslog:
-      - syslog-archive.example.com:514
-      - logstash.example.com:5514
+      - address: syslog-archive.example.com
+        port: 514
+        protocol: udp
+      - address: logstash.example.com
+        port: 5514
+        protocol: tcp

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -54,7 +54,7 @@ jack['system'].each do |system|
 
   yaml_output['system'] = system['system']
 
-  yaml_output['services'] = { 'syslog' => system['domain.services.syslog'] }
+  yaml_output['service'] = { 'syslog' => system['net.service.syslog'] }
 
   File.open("#{options[:output]}/#{system['net.dns.fqdn']}.yaml", File::CREAT | File::TRUNC | File::WRONLY, 0644) do |yamlfile|
     yamlfile << { 'palletjack' => yaml_output }.to_yaml

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -54,6 +54,8 @@ jack['system'].each do |system|
 
   yaml_output['system'] = system['system']
 
+  yaml_output['services'] = { 'syslog' => system['domain.services.syslog'] }
+
   File.open("#{options[:output]}/#{system['net.dns.fqdn']}.yaml", File::CREAT | File::TRUNC | File::WRONLY, 0644) do |yamlfile|
     yamlfile << { 'palletjack' => yaml_output }.to_yaml
   end


### PR DESCRIPTION
Include central Syslog archive configuration in the warehouse (as an attribute of a domain), with examples and documentation.

I'm not really happy with the namespace `domain.services.syslog`, but haven't thought of anything better.
