### PR TITLE
Allow create_system to accept either OS or Netinstall option

### DIFF
--- a/tools/create_system
+++ b/tools/create_system
@@ -8,7 +8,7 @@ require 'optparse'
 $options = {}
 
 opts = OptionParser.new
-opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -s <system> -d <domain> -o <os>
+opts.banner = "Usage: #{$PROGRAM_NAME} -w <warehouse> -s <system> -d <domain> [ -o <os> | -n <netinstall> ]
 
 Create system objects in a warehouse
 
@@ -17,12 +17,14 @@ opts.on('-w DIR', '--warehouse DIR', 'warehouse directory', String) { |dir| $opt
 opts.on('-s SYSTEM', '--system SYSTEM', 'system name', String) { |system| $options[:system] = system }
 opts.on('-d DOMAIN', '--domain DOMAIN', 'domain name', String) { |domain| $options[:domain] = domain }
 opts.on('-o OS', '--os OS', 'operating system name', String) { |os| $options[:os] = os }
+opts.on('-n OS', '--netinstall NETINSTALL', 'network installation profile', String) { |netinstall| $options[:netinstall] = netinstall }
 opts.parse!
 
 if not $options[:warehouse] or
     not $options[:system] or
     not $options[:domain] or
-    not $options[:os] or
+    not ( $options[:os] or $options[:netinstall] ) or
+    ( $options[:os] and $options[:netinstall] ) or
     not File.directory?($options[:warehouse])
   puts opts.to_s
   exit 1
@@ -54,5 +56,11 @@ end
 
 warehouse_symlink("domain/#{$options[:domain]}/",
                   "system/#{$options[:system]}/domain")
-warehouse_symlink("os/#{$options[:os]}/",
-                  "system/#{$options[:system]}/os")
+
+if $options[:os]
+  warehouse_symlink("os/#{$options[:os]}/",
+                    "system/#{$options[:system]}/os")
+elsif $options[:netinstall]
+  warehouse_symlink("netinstall/#{$options[:netinstall]}/",
+                    "system/#{$options[:system]}/netinstall")
+end


### PR DESCRIPTION
Now that we have a working network installation system, allow create_system to
specify a netinstall profile. The netinstall object then inherits from an OS
object.

Closes #62.
