### PR TITLE
Don't dot DNS names

### DIFF
--- a/examples/warehouse/domain/example.com/dns.yaml
+++ b/examples/warehouse/domain/example.com/dns.yaml
@@ -6,8 +6,8 @@ net:
       - priority: 20
         server: mail2.example.com
     ns:
-      - ns1.example.com
-      - ns2.example.com
+      - ns1.example.com.
+      - ns2
     soa-ns: ns1.example.com.
     soa-contact: hostmaster@example.com
     cname:

--- a/examples/warehouse/domain/example.com/dns.yaml
+++ b/examples/warehouse/domain/example.com/dns.yaml
@@ -8,7 +8,7 @@ net:
     ns:
       - ns1.example.com
       - ns2.example.com
-    soa-ns: ns1.example.com
+    soa-ns: ns1.example.com.
     soa-contact: hostmaster@example.com
     cname:
       mail2: ns2

--- a/examples/warehouse/domain/example.com/dns.yaml
+++ b/examples/warehouse/domain/example.com/dns.yaml
@@ -2,9 +2,9 @@ net:
   dns:
     mx:
       - priority: 10
-        server: mail.example.com
+        server: mail.example.com.
       - priority: 20
-        server: mail2.example.com
+        server: mail2
     ns:
       - ns1.example.com.
       - ns2

--- a/tools/palletjack2knot
+++ b/tools/palletjack2knot
@@ -86,7 +86,7 @@ File.open("#{options[:output]}/zones.conf",
         mx = DNS::Zone::RR::MX.new
         mx.label = absolute_domain_name
         mx.priority = server['priority']
-        mx.exchange = "#{server['server']}."
+        mx.exchange = server['server']
         zone.records << mx
       end
     end

--- a/tools/palletjack2knot
+++ b/tools/palletjack2knot
@@ -78,7 +78,7 @@ File.open("#{options[:output]}/zones.conf",
 
     zone.soa.serial = serial
     zone.soa.label = absolute_domain_name
-    zone.soa.nameserver = "#{domain['net.dns.soa-ns']}."
+    zone.soa.nameserver = domain['net.dns.soa-ns']
     zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
 
     if domain['net.dns.mx']
@@ -168,7 +168,7 @@ File.open("#{options[:output]}/zones.conf",
 
     reverse_zone.soa.serial = serial
     reverse_zone.soa.label = "#{reverse_zone.origin}."
-    reverse_zone.soa.nameserver = "#{domain['net.dns.soa-ns']}."
+    reverse_zone.soa.nameserver = domain['net.dns.soa-ns']
     reverse_zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
 
     domain['net.dns.ns'].each do |address|

--- a/tools/palletjack2knot
+++ b/tools/palletjack2knot
@@ -94,7 +94,7 @@ File.open("#{options[:output]}/zones.conf",
     domain['net.dns.ns'].each do |address|
       ns = DNS::Zone::RR::NS.new
       ns.label = absolute_domain_name
-      ns.nameserver = "#{address}."
+      ns.nameserver = address
       zone.records << ns
     end
 
@@ -174,7 +174,7 @@ File.open("#{options[:output]}/zones.conf",
     domain['net.dns.ns'].each do |address|
       ns = DNS::Zone::RR::NS.new
       ns.label = "#{reverse_zone.origin}."
-      ns.nameserver = "#{address}."
+      ns.nameserver = address
       reverse_zone.records << ns
     end
 


### PR DESCRIPTION
Don't unconditionally add dots to DNS names from the warehouse.

Closes #49.
