### PR TITLE
When reading the warehouse, ignore hidden files

### DIFF
--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -41,8 +41,9 @@ class PalletJack
       boxes = Array.new
 
       super(jack.dag, pallet:{kind => name})
-      
+
       Dir.foreach(path) do |file|
+        next if file[0] == '.'
         filepath = File.join(path, file)
         filestat = File.lstat(filepath)
         case


### PR DESCRIPTION
Emacs uses lock files in the form of symbolic links called `.#<filename>` and pointing to a string containing username, hostname and PID of the Emacs process currently editing a file. Pallet Jack gets confused when reading these, so they need to be skipped. Skipping everything starting with `.` has the additional advantage of not surprising the user with hidden data.

Closes #44.
