### PR TITLE
Use KVDAG relations to find parents and children

### DIFF
--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -2,6 +2,9 @@ class PalletJack
   # PalletJack managed pallet of key boxes inside a warehouse.
   class Pallet < KVDAG::Vertex
 
+    attr_reader :name
+    attr_reader :kind
+
     # N.B: A pallet should never be created manually; use
     # +PalletJack::new+ to initialize a complete warehouse.
     #
@@ -36,11 +39,11 @@ class PalletJack
     def initialize(jack, path) #:notnew:
       @jack = jack
       @path = path
-      ppath, name = File.split(path)
-      pppath, kind = File.split(ppath)
+      ppath, @name = File.split(path)
+      pppath, @kind = File.split(ppath)
       boxes = Array.new
 
-      super(jack.dag, pallet:{kind => name})
+      super(jack.dag, pallet:{@kind => @name})
 
       Dir.foreach(path) do |file|
         next if file[0] == '.'
@@ -60,7 +63,7 @@ class PalletJack
       end
       merge!(pallet:{boxes: boxes})
       @jack.keytrans_writer.transform!(self)
-      @jack.pallets[kind][name] = self
+      @jack.pallets[@kind][@name] = self
     end
 
     def inspect

--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -18,7 +18,7 @@ class PalletJack
 
     def Pallet.new(jack, path) #:doc:
       ppath, name = File.split(path)
-      pppath, kind = File.split(ppath)
+      _, kind = File.split(ppath)
 
       jack.pallets[kind] ||= Hash.new
       jack.pallets[kind][name] || super
@@ -40,7 +40,7 @@ class PalletJack
       @jack = jack
       @path = path
       ppath, @name = File.split(path)
-      pppath, @kind = File.split(ppath)
+      _, @kind = File.split(ppath)
       boxes = Array.new
 
       super(jack.dag, pallet:{@kind => @name})

--- a/tools/dump_pallet
+++ b/tools/dump_pallet
@@ -31,7 +31,11 @@ def dump_pallets(pallets)
   if pallets.length == 0
     puts 'No matching pallets found.'
   end
-  pallets.each {|p| puts p.to_yaml}
+  pallets.each do |p|
+    puts "---"
+    puts "# #{p.kind}: #{p.name}"
+    puts p.to_yaml
+  end
 end
 
 # Since we used the destructive opts.parse! above, all options were

--- a/tools/palletjack2kea
+++ b/tools/palletjack2kea
@@ -87,9 +87,8 @@ jack['ipv4_network'].each do |net|
     }
   end
 
-  jack['ipv4_interface',
-       with_all:{'pallet.ipv4_network' =>
-                 net['pallet.ipv4_network']}].each do |interface|
+  net.children.each do |interface|
+    next unless interface.kind == 'ipv4_interface'
     next if not interface['net.layer2.address']
     net_config['reservations'] << {
       'hw-address' => interface['net.layer2.address'],

--- a/tools/palletjack2kea
+++ b/tools/palletjack2kea
@@ -89,7 +89,7 @@ jack['ipv4_network'].each do |net|
 
   net.children.each do |interface|
     next unless interface.kind == 'ipv4_interface'
-    next if not interface['net.layer2.address']
+    next unless interface['net.layer2.address']
     net_config['reservations'] << {
       'hw-address' => interface['net.layer2.address'],
       'ip-address' => interface['net.ipv4.address'],

--- a/tools/palletjack2knot
+++ b/tools/palletjack2knot
@@ -121,9 +121,8 @@ File.open("#{options[:output]}/zones.conf",
       end
     end
 
-    jack['ipv4_interface',
-         with_all:{'net.dns.domain' =>
-           domain['net.dns.domain']}].each do |interface|
+    domain.children.each do |interface|
+      next unless interface.kind == 'ipv4_interface'
       a = DNS::Zone::RR::A.new
       a.label = interface['net.dns.name']
       a.address = interface['net.ipv4.address']
@@ -178,9 +177,8 @@ File.open("#{options[:output]}/zones.conf",
       reverse_zone.records << ns
     end
 
-    jack['ipv4_interface',
-         with_all:{'net.dns.domain' =>
-           domain['net.dns.domain']}].each do |interface|
+    domain.children.each do |interface|
+      next unless interface.kind == 'ipv4_interface'
       ptr = DNS::Zone::RR::PTR.new
       ptr.label = IP.new(interface['net.ipv4.address']).to_arpa
       ptr.name = "#{interface['net.dns.fqdn']}."

--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -202,9 +202,8 @@ end
 # Generate pxe default menu links for each system
 
 $jack['system'].each do |system|
-  $jack['ipv4_interface',
-       with_all:{'pallet.system' =>
-                 system['pallet.system']}].each do |nic|
+  system.children.each do |nic|
+    next unless nic.kind == 'ipv4_interface'
     if system['host.pxelinux.config']
       filename = "#{$options[:output]}/pxelinux.cfg/01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
       FileUtils.ln_s("../config/#{system['host.pxelinux.config']}.menu", filename, :force => true)

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -44,8 +44,8 @@ jack = PalletJack.new(options[:warehouse])
 
 jack['system'].each do |system|
   yaml_output = { 'ipv4_interfaces' => {} }
-  jack['ipv4_interface', with_all:{'pallet.system' =>
-      system['system.name']}].each do |interface|
+  system.children.each do |interface|
+    next unless interface.kind == 'ipv4_interface'
     yaml_output['ipv4_interfaces'][interface['net.layer2.name']] = {
       interface['net.ipv4.address'] =>
       interface.filter('net.ipv4', 'net.layer2').to_hash


### PR DESCRIPTION
Use KVDAG relations to find parents and children, instead of doing linear searches through the entire warehouse each time.

Closes #51.
