### PR TITLE
Fix PalletJack::Tool#pallet_box

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -275,7 +275,7 @@ class PalletJack
 
     def pallet_box(kind, name, box, &block)
       config_file :warehouse, kind, name, "#{box}.yaml" do |box_file|
-        box_file = block.call.deep_stringify_keys.to_yaml
+        box_file << block.call.deep_stringify_keys.to_yaml
       end
     end
 


### PR DESCRIPTION
The `#pallet_box` method of `PalletJack::Tool` incorrectly assigned
the yaml tree for the box to the file handle instead of appending it.
