### PR TITLE
Correct gemspec

### DIFF
--- a/palletjack-tools.gemspec
+++ b/palletjack-tools.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.platform	= Gem::Platform::RUBY
   s.required_ruby_version = '~>2'
   s.add_runtime_dependency 'palletjack', s.version
-  s.add_runtime_dependency 'kvdag', '~> 0.1'
   s.add_runtime_dependency 'dns-zone', '~> 0.3'
   s.add_runtime_dependency 'ruby-ip', '~> 0.9'
   s.files	= [ 'README.md', 'LICENSE' ]

--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.platform	= Gem::Platform::RUBY
   s.required_ruby_version = '~>2'
-  s.add_runtime_dependency 'activesupport', '~>5'
+  s.add_runtime_dependency 'activesupport', '~>4'
   s.add_runtime_dependency 'rugged', '~> 0.24'
   s.add_runtime_dependency 'kvdag', '~>0.1'
   s.files	= [ 'README.md', 'LICENSE' ]


### PR DESCRIPTION
Since PalletJack promises to support ruby~>2, we can't rely on a version of activesupport that requires ruby>2.2. Also, palletjack-tools had an unneccesary dependency on kvdag, that is internal implementation details in the palletjack library.
