### PR TITLE
Child traversal

### DIFF
--- a/palletjack-tools.gemspec
+++ b/palletjack-tools.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Tools for the Pallet Jack Lightweight Configuration Management Database'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/palletjack'
-  s.version	= '0.0.4'
+  s.version	= '0.0.5'
   s.author	= 'Karl-Johan Karlsson'
   s.email	= 'karl-johan.karlsson@saabgroup.com'
   s.license	= 'MIT'

--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.summary	= 'Lightweight Configuration Management Database'
   s.description	= File.read(File.join(File.dirname(__FILE__), 'README.md'))
   s.homepage    = 'https://github.com/saab-simc-admin/palletjack'
-  s.version	= '0.0.4'
+  s.version	= '0.0.5'
   s.author	= 'Calle Englund'
   s.email	= 'calle.englund@saabgroup.com'
   s.license	= 'MIT'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~>2'
   s.add_runtime_dependency 'activesupport', '~>4'
   s.add_runtime_dependency 'rugged', '~> 0.24'
-  s.add_runtime_dependency 'kvdag', '~>0.1'
+  s.add_runtime_dependency 'kvdag', '~>0.1', '>=0.1.1'
   s.files	= [ 'README.md', 'LICENSE' ]
   s.files	+= Dir['lib/**/*.rb']
   s.executables	= []

--- a/tools/palletjack2kea
+++ b/tools/palletjack2kea
@@ -73,9 +73,9 @@ PalletJack2Kea.run do
         dhcp4_option(67, 'boot-file-name', net['net.dhcp.boot-file'])
     end
 
-    net.children.each do |interface|
-      next unless interface.kind == 'ipv4_interface'
-      next unless interface['net.layer2.address']
+    net.children(kind:'ipv4_interface',
+                 none?:{ 'net.layer2.address' => nil }
+                 ) do |interface|
       net_config['reservations'] << {
         'hw-address' => interface['net.layer2.address'],
         'ip-address' => interface['net.ipv4.address'],

--- a/tools/palletjack2knot
+++ b/tools/palletjack2knot
@@ -102,8 +102,7 @@ PalletJack2Knot.run do
         end
       end
 
-      domain.children.each do |interface|
-        next unless interface.kind == 'ipv4_interface'
+      domain.children(kind:'ipv4_interface') do |interface|
         a = DNS::Zone::RR::A.new
         a.label = interface['net.dns.name']
         a.address = interface['net.ipv4.address']
@@ -153,8 +152,7 @@ PalletJack2Knot.run do
         reverse_zone.records << ns
       end
 
-      domain.children.each do |interface|
-        next unless interface.kind == 'ipv4_interface'
+      domain.children(kind:'ipv4_interface') do |interface|
         ptr = DNS::Zone::RR::PTR.new
         ptr.label = IP.new(interface['net.ipv4.address']).to_arpa
         ptr.name = "#{interface['net.dns.fqdn']}."

--- a/tools/palletjack2pxelinux
+++ b/tools/palletjack2pxelinux
@@ -117,7 +117,7 @@ MENU INCLUDE /config/graphics.conf
 MENU TITLE #{os_label} Installation Menu
 "
 
-      os.children.select{|c| c.kind == 'netinstall'}.each do |netinstall|
+      os.children(kind:'netinstall') do |netinstall|
         config=netinstall['host.pxelinux.config']
         ks_label=(netinstall['host.kickstart.label'] ||
                   netinstall['host.kickstart.variant'] )
@@ -177,8 +177,7 @@ LABEL #{config}
   # Generate pxe default menu links for each system
 
   jack['system'].each do |system|
-    system.children.each do |nic|
-      next unless nic.kind == 'ipv4_interface'
+    system.children(kind:'ipv4_interface') do |nic|
       if system['host.pxelinux.config']
         menuname = "#{system['host.pxelinux.config']}.menu"
         linkname = "01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"

--- a/tools/palletjack2salt
+++ b/tools/palletjack2salt
@@ -38,8 +38,7 @@ PalletJack2Salt.run do
   jack['system'].each do |system|
     yaml_output = { 'ipv4_interfaces' => {} }
 
-    system.children.each do |interface|
-      next unless interface.kind == 'ipv4_interface'
+    system.children(kind:'ipv4_interface') do |interface|
       yaml_output['ipv4_interfaces'][interface['net.layer2.name']] = {
         interface['net.ipv4.address'] =>
         interface.filter('net.ipv4', 'net.layer2').to_hash


### PR DESCRIPTION
All tools have been updated to use new `KVDAG::Vertex#children` filter API. This closes #75.
