### PR TITLE
Send the system's domain name by DHCP

### DIFF
--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '~>2'
   s.add_runtime_dependency 'activesupport', '~>4'
   s.add_runtime_dependency 'rugged', '~> 0.24'
-  s.add_runtime_dependency 'kvdag', '~>0.1', '>=0.1.1'
+  s.add_runtime_dependency 'kvdag', '~>0.1', '>=0.1.2'
   s.files	= [ 'README.md', 'LICENSE' ]
   s.files	+= Dir['lib/**/*.rb']
   s.executables	= []

--- a/tools/palletjack2kea
+++ b/tools/palletjack2kea
@@ -79,7 +79,12 @@ PalletJack2Kea.run do
       net_config['reservations'] << {
         'hw-address' => interface['net.layer2.address'],
         'ip-address' => interface['net.ipv4.address'],
-        'hostname' => interface['net.dns.fqdn']
+        'hostname' => interface['net.dns.fqdn'],
+        'option-data' =>
+        [
+          dhcp4_option(15, 'domain-name',
+            interface.parents(kind:'system').first['net.dns.domain'])
+        ]
       }
     end
 


### PR DESCRIPTION
Get the domain name from the system an interface is connected to, not the interface itself.

Bump keyvaluedag requirement to 0.1.2, to get the backend functionality.

Requires Kea 1.1.0.

Closes #47.
