### PR TITLE
Improved fetch

### DIFF
--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -34,83 +34,32 @@ class PalletJack
 
   # Search for pallets in a PalletJack warehouse
   #
-  # :call-seq:
-  #   [kind]                        -> set of pallets
-  #   [kind, name: pallet_name]     -> set of pallets
-  #   [kind, with_all:{ matches }]  -> set of pallets
-  #   [kind, with_any:{ matches }]  -> set of pallets
-  #   [kind, with_none:{ matches }] -> set of pallets
+  # The search is filtered by KVDAG::Vertex#match? expressions.
   #
-  # Return all pallets of +kind+, optionally restricting by
-  # keypath matches.
+  # Useful Pallet methods to match for include:
   #
-  # +pallet_name+ is the filesystem +basename+ for the pallet.
-  #
-  # +matches+ should be a hash with "key.path" strings as keys,
-  # and either string or regexp values to match against.
+  # kind:: the kind of pallet
+  # name:: the filesystem +basename+ of the pallet
 
-  def [](kind, options = {})
-    match_enumerator = {
-      :with_all  => :all?,
-      :with_any  => :any?,
-      :with_none => :none?
-    }
-    result = Set.new
-
-    case
-    when options.empty?
-      result += @pallets[kind].values
-    when options[:name]
-      if p = @pallets[kind][options[:name]]
-        result << p
-      end
-    else
-      match_enumerator.keys.each do |tag|
-        if options[tag]
-          @pallets[kind].each do |_, pallet|
-            if options[tag].send(match_enumerator[tag]) do |key, value|
-                case value
-                when Regexp
-                  pallet[key] =~ value
-                else
-                  pallet[key].to_s == value.to_s
-                end
-              end
-            then
-              result << pallet
-            end
-          end
-        end
-      end
-    end
-
-    result
+  def [](filter = {})
+    @dag.vertices(filter)
   end
 
   # Fetch a single pallet from a PalletJack warehouse
   #
-  # :call-seq:
-  #   fetch(kind)                        -> pallet or KeyError
-  #   fetch(kind, name: name)            -> pallet or KeyError
-  #   fetch(kind, with_all:{ matches })  -> pallet or KeyError
-  #   fetch(kind, with_any:{ matches })  -> pallet or KeyError
-  #   fetch(kind, with_none:{ matches }) -> pallet or KeyError
+  # The search is filtered by KVDAG::Vertex#match? expressions.
   #
-  # Return exactly one pallet of +kind+, optionally restricting by
-  # keypath matches.
+  # Useful Pallet methods to match for include:
   #
-  # Raise a KeyError if there is more or less than one match.
-  #
-  # +matches+ should be a hash with "key.path" strings as keys,
-  # and either string or regexp values to match against.
-  #
+  # kind:: the kind of pallet
+  # name:: the filesystem +basename+ of the pallet
 
-  def fetch(kind, options = {})
-    result = self[kind, options]
-    if result.length != 1 then
-      raise KeyError.new("\"#{kind}\", #{options} matched #{result.length} pallets")
+  def fetch(filter = {})
+    result = self[filter]
+
+    if result.length != 1
+      raise KeyError.new("#{options} matched #{result.length} pallets")
     end
-
     result.first
   end
 end

--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -43,7 +43,7 @@ class PalletJack
       _, @kind = File.split(ppath)
       boxes = Array.new
 
-      super(jack.dag, pallet:{@kind => @name})
+      super(jack, pallet:{@kind => @name})
 
       Dir.foreach(path) do |file|
         next if file[0] == '.'

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -25,7 +25,7 @@ class PalletJack
   #   end
   #
   #   MyTool.run do
-  #     jack['system'].each do |sys|
+  #     jack.each(kind:'system') do |sys|
   #        config_dir :output, sys.name
   #        config_file :output, sys.name, "dump.yaml" do |file|
   #          file << sys.to_yaml
@@ -44,7 +44,7 @@ class PalletJack
     #
     # Example:
     #
-    #   MyTool.run { jack['system'].each {|sys| puts sys.to_yaml } }
+    #   MyTool.run { jack.each(kind:'system') {|sys| puts sys.to_yaml } }
 
     def self.run(&block)
       instance.instance_eval(&block)
@@ -165,7 +165,7 @@ class PalletJack
 
     def jack
       abort(usage) unless options[:warehouse]
-      @jack ||= PalletJack.new(options[:warehouse])
+      @jack ||= PalletJack.load(options[:warehouse])
     end
 
     # Build a filesystem path from path components

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,5 @@
-class PalletJack
+require 'kvdag'
+
+class PalletJack < KVDAG
   VERSION = "0.1.0"
 end

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 class PalletJack
-  VERSION = "0.0.5"
+  VERSION = "0.1.0"
 end

--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '~>4'
   spec.add_runtime_dependency 'rugged', '~> 0.24'
-  spec.add_runtime_dependency 'kvdag', '~> 0.1.2'
+  spec.add_runtime_dependency 'kvdag', '~> 0.1.3'
 
   spec.add_development_dependency "bundler", "~> 1.7.8"
   spec.add_development_dependency "rake", "~> 0.9.6"

--- a/spec/example-warehouse_spec.rb
+++ b/spec/example-warehouse_spec.rb
@@ -12,7 +12,7 @@ describe 'Example warehouse' do
 
   context 'when loaded' do
     before :all do
-      @jack = PalletJack.new($EXAMPLE_WAREHOUSE)
+      @jack = PalletJack.load($EXAMPLE_WAREHOUSE)
     end
 
     it 'has pallets' do
@@ -20,12 +20,12 @@ describe 'Example warehouse' do
     end
 
     it 'has "system" kind of pallets' do
-      expect(@jack['system']).not_to be_empty
+      expect(@jack[kind:'system']).not_to be_empty
     end
 
     context 'system "vmhost1"' do
       before :all do
-        @sys = @jack.fetch('system', name:'vmhost1')
+        @sys = @jack.fetch(kind:'system', name:'vmhost1')
       end
 
       it 'has kind "system"' do
@@ -55,20 +55,20 @@ describe 'Example warehouse' do
 
     context 'system "__invalid__"' do
       it 'does not exist' do
-        expect(@jack['system', name:'__invalid__']).to be_empty
+        expect(@jack[kind:'system', name:'__invalid__']).to be_empty
       end
     end
 
     it 'has "domain" kind of pallets' do
-      expect(@jack['domain']).not_to be_empty
+      expect(@jack[kind:'domain']).not_to be_empty
     end
 
     it 'has "ipv4_interface" kind of pallets' do
-      expect(@jack['ipv4_interface']).not_to be_empty
+      expect(@jack[kind:'ipv4_interface']).not_to be_empty
     end
 
     it 'does not have "__invalid__" kind of pallets' do
-      expect(@jack['__invalid__']).to be_empty
+      expect(@jack[kind:'__invalid__']).to be_empty
     end
   end
 end

--- a/spec/palletjack_spec.rb
+++ b/spec/palletjack_spec.rb
@@ -6,6 +6,6 @@ describe PalletJack do
   end
 
   it 'requires a warehouse' do
-    expect{ PalletJack.new('__INVALID__') }.to raise_error Errno::ENOENT
+    expect{ PalletJack.load('__INVALID__') }.to raise_error Errno::ENOENT
   end
 end

--- a/tools/exe/dump_pallet
+++ b/tools/exe/dump_pallet
@@ -41,10 +41,10 @@ DumpPallet.run do
   # Since the Tool framework uses destructive opts.parse!, all options
   # were removed from ARGV, leaving just the names to search for.
   if ARGV.empty?
-    dump_pallets(jack[options[:type]])
+    dump_pallets jack[kind: options[:type]]
   else
     ARGV.each do |name|
-      dump_pallets(jack[options[:type], name:name])
+      dump_pallets jack[kind: options[:type], name: name]
     end
   end
 end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -33,13 +33,13 @@ end
 PalletJack2Kea.run do
   kea_config = { 'Dhcp4' => {} }
 
-  jack['service', name:options[:service]].each do |service_config|
+  jack.each(kind:'service', name:options[:service]) do |service_config|
     kea_config['Dhcp4'] = service_config['service.kea_v4']
   end
 
   kea_config['Dhcp4']['subnet4'] = []
 
-  jack['ipv4_network'].each do |net|
+  jack.each(kind:'ipv4_network') do |net|
     net_config = {'subnet' => net['net.ipv4.cidr'],
                   'reservations' => [],
                   'option-data' => []}

--- a/tools/exe/palletjack2knot
+++ b/tools/exe/palletjack2knot
@@ -49,7 +49,7 @@ PalletJack2Knot.run do
   config_file :output, 'zones.conf' do |conf_file|
     conf_file << git_header('palletjack2knot')
 
-    jack['domain'].each do |domain|
+    jack.each(kind:'domain') do |domain|
       absolute_domain_name = "#{domain['net.dns.domain']}."
 
       zone = DNS::Zone.new

--- a/tools/exe/palletjack2pxelinux
+++ b/tools/exe/palletjack2pxelinux
@@ -158,7 +158,7 @@ MENU INCLUDE /config/graphics.conf
 MENU TITLE Linux Installation Menu
 "
 
-    jack['os'].each do |os|
+    jack.each(kind:'os') do |os|
       next unless config=os['host.pxelinux.config']
 
       label=config.gsub(/-/, ' ')
@@ -176,7 +176,7 @@ LABEL #{config}
 
   # Generate pxe default menu links for each system
 
-  jack['system'].each do |system|
+  jack.each(kind:'system') do |system|
     system.children(kind:'ipv4_interface') do |nic|
       if system['host.pxelinux.config']
         menuname = "#{system['host.pxelinux.config']}.menu"

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -35,7 +35,7 @@ Write Salt pillar data from a Palletjack warehouse, one YAML file per system"
 end
 
 PalletJack2Salt.run do
-  jack['system'].each do |system|
+  jack.each(kind:'system') do |system|
     yaml_output = { 'ipv4_interfaces' => {} }
 
     system.children(kind:'ipv4_interface') do |interface|

--- a/tools/exe/palletjack2unbound
+++ b/tools/exe/palletjack2unbound
@@ -77,8 +77,10 @@ stub-zone:
 
   # Generate unbound service configuration
 
-  def unbound_config(file_name, service_config)
-    config_file :local_dir, "#{file_name}.conf" do |configfile|
+  def unbound_config(service_name)
+    service_config = jack.fetch(kind:'service', name: service_name)
+
+    config_file :local_dir, "#{service_name}.conf" do |configfile|
       configfile << git_header('palletjack2unbound')
       service_config["service.unbound.server"].each do |config|
         config.each do |key, value|
@@ -93,12 +95,12 @@ PalletJack2Unbound.run do
   config_dir :conf_dir
   config_dir :local_dir
 
-  jack['domain'].each do |domain|
+  jack.each(kind:'domain') do |domain|
     zone = domain['net.dns.domain']
     stub_addrs = []
 
     domain['net.dns.ns'].each do |ns|
-      jack['ipv4_interface', with_all:{'net.dns.fqdn' => ns}].each do |ipv4|
+      jack.each(kind:'ipv4_interface', all?:{'net.dns.fqdn' => ns}) do |ipv4|
         stub_addrs << ipv4['net.ipv4.address']
       end
     end
@@ -123,7 +125,5 @@ PalletJack2Unbound.run do
     stub_zone(reverse_zone, stub_addrs, transparent: rfc1918?(ip_net))
   end
 
-  jack['service', name: options[:service]].each do |service_config|
-    unbound_config(options[:service], service_config)
-  end
+  unbound_config(options[:service])
 end


### PR DESCRIPTION
Change pallet fetch APIs to match KVDAG vertex filtering.

Make `PalletJack` a subclass of `KVDAG`, which is what is actually is. Break warehouse loading out into its own method, and add a new class method `::load` that will create a new `PalletJack` and load a warehouse. This breaks everything, and bumps gem minor version.

As an added bonus `jack[...].each` can be replaced by `jack.each(...)`.

Depends on saab-simc-admin/keyvaluedag#13. Closes #80.
