### PR TITLE
Tool tests

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -22,28 +22,62 @@ class PalletJack
   #
   #       required_option :output
   #     end
+  #
+  #     attr_reader :state
+  #
+  #     def process
+  #       @state = {}
+  #       jack.each(kind:'system') do |sys|
+  #         @state[sys.name] = sys
+  #       end
+  #     end
+  #
+  #     def output
+  #       @state.each do |name, data|
+  #         config_dir :output, name
+  #         config_file :output, name, "dump.yaml" do |file|
+  #           file << data.to_yaml
+  #         end
+  #       end
+  #     end
   #   end
   #
-  #   MyTool.run do
-  #     jack.each(kind:'system') do |sys|
-  #        config_dir :output, sys.name
-  #        config_file :output, sys.name, "dump.yaml" do |file|
-  #          file << sys.to_yaml
-  #        end
-  #     end
+  #   if __FILE__ == $0
+  #     MyTool.run
   #   end
 
   class Tool
     include Singleton
 
+    # v0.1.1 API:
+    #
+    # :call-seq:
+    # run
+    #
+    # Main tool framework driver.
+    #
+    # Run the entire tool; setup, process and output. Actual tools
+    # will want to use this function, while testing and other
+    # activities that require poking around in internal state will
+    # want to run the partial functions instead.
+    #
+    # Example:
+    #
+    # if __FILE__ == $0
+    #   MyTool.run
+    # end
+
+    # v0.1.0 API, retained until all tools have been updated to
+    # v0.1.1:
+    #
+    # :call-seq:
+    # run &block
+    #
     # Run the +block+ given in the context of the tool singleton instance
     # as convenience for simple tools.
     #
     # More complex tools probably want to override parse_options to
     # add option parsing, and split functionality into multiple methods.
-    #
-    # For testable tools, see the methods #process and #output
-    # instead.
     #
     # Example:
     #
@@ -82,8 +116,7 @@ class PalletJack
     def process
     end
 
-    # Run the #outputter function (defined in a specific tool class)
-    # to output data to disk in its final format.
+    # Output data in its final format, probably to disk or stdout.
     #
     # Example:
     #
@@ -105,10 +138,10 @@ class PalletJack
       ARGV
     end
 
-    # Initialize the singleton instance
+    # Set up the singleton instance
     #
-    # Default initialization will add options for --warehouse and --help
-    # to the OptionParser, and set the banner to something useful.
+    # Default setup will add options for --warehouse and --help to the
+    # OptionParser, and set the banner to something useful.
     #
     # Any exceptions raised during option parsing will abort execution
     # with usage information.
@@ -132,13 +165,6 @@ class PalletJack
       @option_checks.each {|check| check.call }
     rescue
       abort(usage)
-    end
-
-    # Do nothing in the automatically called initialize function,
-    # since we want to be able to override everything before
-    # configuration.
-
-    def initialize #:notnew:
     end
 
     # Additional option parsing

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -42,12 +42,50 @@ class PalletJack
     # More complex tools probably want to override parse_options to
     # add option parsing, and split functionality into multiple methods.
     #
+    # For testable tools, see the methods #process and #output
+    # instead.
+    #
     # Example:
     #
     #   MyTool.run { jack.each(kind:'system') {|sys| puts sys.to_yaml } }
 
     def self.run(&block)
       instance.instance_eval(&block)
+    end
+
+    # Generate data in an internal format, saving it for later testing
+    # or writing to disk by #output.
+    #
+    # Override this function in specific tool classes.
+    #
+    # Example:
+    #
+    #   class MyTool < PalletJack::Tool
+    #     def process
+    #       @systems = Set.new
+    #       jack.each(kind:'system') do |s|
+    #         @systems << s
+    #       end
+    #     end
+    #   end
+
+    def process
+    end
+
+    # Run the #outputter function (defined in a specific tool class)
+    # to output data to disk in its final format.
+    #
+    # Example:
+    #
+    #   class MyTool < PalletJack::Tool
+    #     def output
+    #       @systems.each do |s|
+    #         puts s.name
+    #       end
+    #     end
+    #   end
+
+    def output
     end
 
     # Initialize the singleton instance

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -50,7 +50,17 @@ class PalletJack
     #   MyTool.run { jack.each(kind:'system') {|sys| puts sys.to_yaml } }
 
     def self.run(&block)
-      instance.instance_eval(&block)
+      if block
+        # v0.1.0 API. When all tools have been ported, remove this and
+        # bump the minor version number.
+        instance.setup
+        instance.instance_eval(&block)
+      else
+        # v0.1.1 API
+        instance.setup
+        instance.process
+        instance.output
+      end
     end
 
     # Generate data in an internal format, saving it for later testing
@@ -103,7 +113,7 @@ class PalletJack
     # Any exceptions raised during option parsing will abort execution
     # with usage information.
 
-    def initialize #:notnew:
+    def setup
       @parser = OptionParser.new
       @options = {}
       @option_checks = []
@@ -122,6 +132,13 @@ class PalletJack
       @option_checks.each {|check| check.call }
     rescue
       abort(usage)
+    end
+
+    # Do nothing in the automatically called initialize function,
+    # since we want to be able to override everything before
+    # configuration.
+
+    def initialize #:notnew:
     end
 
     # Additional option parsing

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -88,6 +88,13 @@ class PalletJack
     def output
     end
 
+    # Return the command line argument list to be used. Replace this
+    # method when testing.
+
+    def argv
+      ARGV
+    end
+
     # Initialize the singleton instance
     #
     # Default initialization will add options for --warehouse and --help
@@ -111,7 +118,7 @@ class PalletJack
 
       parse_options(@parser)
 
-      @parser.parse!
+      @parser.parse!(argv)
       @option_checks.each {|check| check.call }
     rescue
       abort(usage)

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,5 @@
 require 'kvdag'
 
 class PalletJack < KVDAG
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7.8"
   spec.add_development_dependency "rake", "~> 0.9.6"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
+  spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.has_rdoc	= true
 end

--- a/spec/palletjack-tool_spec.rb
+++ b/spec/palletjack-tool_spec.rb
@@ -7,25 +7,31 @@ describe PalletJack::Tool do
     expect{ PalletJack::Tool.instance }.not_to raise_error
   end
 
-  it 'can run a block in its instance context' do
-    expect(PalletJack::Tool.run { self.class }).to be PalletJack::Tool
-  end
+  context 'without a command line' do
+    before :each do
+      allow(PalletJack::Tool.instance).to receive(:argv).and_return([])
+    end
 
-  it 'keeps state between invocations' do
-    PalletJack::Tool.run { @__rspec__remember_me = true }
-    expect(PalletJack::Tool.run { @__rspec__remember_me }).to be true
-  end
+    it 'can run a block in its instance context' do
+      expect(PalletJack::Tool.run { self.class }).to be PalletJack::Tool
+    end
 
-  it 'requires a warehouse' do
-    allow($stderr).to receive :write # Drop stderr output from #abort
-    expect{ PalletJack::Tool.run { jack } }.to raise_error SystemExit
+    it 'keeps state between invocations' do
+      PalletJack::Tool.run { @__rspec__remember_me = true }
+      expect(PalletJack::Tool.run { @__rspec__remember_me }).to be true
+    end
+
+    it 'requires a warehouse' do
+      allow($stderr).to receive :write # Drop stderr output from #abort
+      expect{ PalletJack::Tool.run { jack } }.to raise_error SystemExit
+    end
   end
 
   context 'with example warehouse' do
     before :each do
       class TestTool < PalletJack::Tool
-        def parse_options(_)
-          options[:warehouse] = $EXAMPLE_WAREHOUSE
+        def options
+          { warehouse:$EXAMPLE_WAREHOUSE }
         end
       end
 

--- a/tools/exe/dump_pallet
+++ b/tools/exe/dump_pallet
@@ -39,11 +39,11 @@ end
 
 DumpPallet.run do
   # Since the Tool framework uses destructive opts.parse!, all options
-  # were removed from ARGV, leaving just the names to search for.
-  if ARGV.empty?
+  # were removed from argv, leaving just the names to search for.
+  if argv.empty?
     dump_pallets jack[kind: options[:type]]
   else
-    ARGV.each do |name|
+    argv.each do |name|
       dump_pallets jack[kind: options[:type], name: name]
     end
   end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -28,70 +28,78 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
       'data' => data
     }
   end
-end
 
-PalletJack2Kea.run do
-  kea_config = { 'Dhcp4' => {} }
+  def process
+    @kea_config = { 'Dhcp4' => {} }
 
-  jack.each(kind:'service', name:options[:service]) do |service_config|
-    kea_config['Dhcp4'] = service_config['service.kea_v4']
-  end
-
-  kea_config['Dhcp4']['subnet4'] = []
-
-  jack.each(kind:'ipv4_network') do |net|
-    net_config = {'subnet' => net['net.ipv4.cidr'],
-                  'reservations' => [],
-                  'option-data' => []}
-    if net['net.ipv4.gateway']
-      net_config['option-data'] <<
-        dhcp4_option(3, 'routers', net['net.ipv4.gateway'])
+    jack.each(kind:'service', name:options[:service]) do |service_config|
+      @kea_config['Dhcp4'] = service_config['service.kea_v4']
     end
 
-    if net['net.dns.resolver']
-      resolvers = ''
-      net['net.dns.resolver'].each do |resolver|
-        resolvers << resolver << ', '
+    @kea_config['Dhcp4']['subnet4'] = []
+
+    jack.each(kind:'ipv4_network') do |net|
+      net_config = {'subnet' => net['net.ipv4.cidr'],
+        'reservations' => [],
+        'option-data' => []}
+      if net['net.ipv4.gateway']
+        net_config['option-data'] <<
+          dhcp4_option(3, 'routers', net['net.ipv4.gateway'])
       end
 
-      net_config['option-data'] <<
-        dhcp4_option(6, 'domain-name-servers', resolvers.chomp(', '))
+      if net['net.dns.resolver']
+        resolvers = ''
+        net['net.dns.resolver'].each do |resolver|
+          resolvers << resolver << ', '
+        end
+
+        net_config['option-data'] <<
+          dhcp4_option(6, 'domain-name-servers', resolvers.chomp(', '))
+      end
+
+      if net['net.dhcp.tftp-server']
+        net_config['option-data'] <<
+          dhcp4_option(66, 'tftp-server-name', net['net.dhcp.tftp-server'])
+
+        # Option 66/tftp-server-name is the standard way of sending a
+        # TFTP server address, but some DHCP clients still want it in
+        # the next-server field.
+        net_config['next-server'] = net['net.dhcp.tftp-server']
+      end
+
+      if net['net.dhcp.boot-file']
+        net_config['option-data'] <<
+          dhcp4_option(67, 'boot-file-name', net['net.dhcp.boot-file'])
+      end
+
+      net.children(kind:'ipv4_interface',
+                   none?:{ 'net.layer2.address' => nil }
+                  ) do |interface|
+        net_config['reservations'] << {
+          'hw-address' => interface['net.layer2.address'],
+          'ip-address' => interface['net.ipv4.address'],
+          'hostname' => interface['net.dns.fqdn'],
+          'option-data' =>
+          [
+            dhcp4_option(15, 'domain-name',
+                         interface.parents(kind:'system').first['net.dns.domain'])
+          ]
+        }
+      end
+
+      @kea_config['Dhcp4']['subnet4'] << net_config
     end
-
-    if net['net.dhcp.tftp-server']
-      net_config['option-data'] <<
-        dhcp4_option(66, 'tftp-server-name', net['net.dhcp.tftp-server'])
-
-      # Option 66/tftp-server-name is the standard way of sending a
-      # TFTP server address, but some DHCP clients still want it in
-      # the next-server field.
-      net_config['next-server'] = net['net.dhcp.tftp-server']
-    end
-
-    if net['net.dhcp.boot-file']
-      net_config['option-data'] <<
-        dhcp4_option(67, 'boot-file-name', net['net.dhcp.boot-file'])
-    end
-
-    net.children(kind:'ipv4_interface',
-                 none?:{ 'net.layer2.address' => nil }
-                 ) do |interface|
-      net_config['reservations'] << {
-        'hw-address' => interface['net.layer2.address'],
-        'ip-address' => interface['net.ipv4.address'],
-        'hostname' => interface['net.dns.fqdn'],
-        'option-data' =>
-        [
-          dhcp4_option(15, 'domain-name',
-            interface.parents(kind:'system').first['net.dns.domain'])
-        ]
-      }
-    end
-
-    kea_config['Dhcp4']['subnet4'] << net_config
   end
 
-  puts git_header('palletjack2kea')
+  def output
+    puts git_header('palletjack2kea')
 
-  jj kea_config
+    jj @kea_config
+  end
+end
+
+if __FILE__ == $0
+  tool = PalletJack2Kea.instance
+  tool.process
+  tool.output
 end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -104,7 +104,5 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
 end
 
 if __FILE__ == $0
-  tool = PalletJack2Kea.instance
-  tool.process
-  tool.output
+  PalletJack2Kea.run
 end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -29,6 +29,11 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
     }
   end
 
+  # The internal representation of the generated configuration, ready
+  # to be tested or printed.
+
+  attr_reader :kea_config
+
   def process
     @kea_config = { 'Dhcp4' => {} }
 

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -69,7 +69,5 @@ Write Salt pillar data from a Palletjack warehouse, one YAML file per system"
 end
 
 if __FILE__ == $0
-  tool = PalletJack2Salt.instance
-  tool.process
-  tool.output
+  PalletJack2Salt.run
 end

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -32,25 +32,44 @@ Write Salt pillar data from a Palletjack warehouse, one YAML file per system"
 
     required_option :output
   end
-end
 
-PalletJack2Salt.run do
-  jack.each(kind:'system') do |system|
-    yaml_output = { 'ipv4_interfaces' => {} }
+  # The internal representation of the generated configuration, ready
+  # to be tested or printed.
 
-    system.children(kind:'ipv4_interface') do |interface|
-      yaml_output['ipv4_interfaces'][interface['net.layer2.name']] = {
-        interface['net.ipv4.address'] =>
-        interface.filter('net.ipv4', 'net.layer2').to_hash
-      }
-    end
+  attr_reader :salt_config
 
-    yaml_output['system'] = system['system']
+  def process
+    @salt_config = {}
 
-    yaml_output['service'] = system['net.service']
+    jack.each(kind:'system') do |system|
+      yaml_output = { 'ipv4_interfaces' => {} }
 
-    config_file :output, "#{system['net.dns.fqdn']}.yaml" do |yamlfile|
-      yamlfile << { 'palletjack' => yaml_output }.to_yaml
+      system.children(kind:'ipv4_interface') do |interface|
+        yaml_output['ipv4_interfaces'][interface['net.layer2.name']] = {
+          interface['net.ipv4.address'] =>
+          interface.filter('net.ipv4', 'net.layer2').to_hash
+        }
+      end
+
+      yaml_output['system'] = system['system']
+      yaml_output['service'] = system['net.service']
+
+      @salt_config[system['net.dns.fqdn']] = { 'palletjack' => yaml_output }
     end
   end
+
+  def output
+    @salt_config.each do |id, config|
+      config_file :output, "#{id}.yaml" do |yamlfile|
+        yamlfile << git_header('palletjack2salt')
+        yamlfile << config.to_yaml
+      end
+    end
+  end
+end
+
+if __FILE__ == $0
+  tool = PalletJack2Salt.instance
+  tool.process
+  tool.output
 end

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -29,7 +29,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7.8"
   spec.add_development_dependency "rake", "~> 0.9.6"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec_structure_matcher", "~> 0.0.6"
+  spec.add_development_dependency "rspec-collection_matchers", "~> 1.1.2"
 
   spec.has_rdoc	= true
 end

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -5,15 +5,12 @@ load "palletjack2kea"
 
 describe 'palletjack2kea' do
   context 'generated configuration' do
-    before :all do
-      class PalletJack2Kea
-        def argv
-          ["-w", $EXAMPLE_WAREHOUSE,
-           "-s", "dhcp-server-example-net"]
-        end
-      end
-
+    before :each do
       @tool = PalletJack2Kea.instance
+      allow(@tool).to receive(:argv).and_return(
+        ["-w", $EXAMPLE_WAREHOUSE,
+         "-s", "dhcp-server-example-net"])
+      @tool.setup
       @tool.process
     end
 

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -1,19 +1,113 @@
 require 'spec_helper'
+require 'rspec_structure_matcher'
+require 'rspec/collection_matchers'
 
 load "palletjack2kea"
 
 describe 'palletjack2kea' do
-  it 'generates the correct JSON tree' do
-    class PalletJack2Kea
-      def argv
-        ["-w", $EXAMPLE_WAREHOUSE,
-          "-s", "dhcp-server-example-net"]
+  context 'generated configuration' do
+    before :all do
+      class PalletJack2Kea
+        def argv
+          ["-w", $EXAMPLE_WAREHOUSE,
+           "-s", "dhcp-server-example-net"]
+        end
       end
+
+      @tool = PalletJack2Kea.instance
+      @tool.process
     end
 
-    tool = PalletJack2Kea.instance
-    tool.process
-    expect(tool.kea_config).to eql ({"Dhcp4"=>{"interfaces-config"=>{"interfaces"=>["*"]}, "lease-database"=>{"type"=>"memfile"}, "valid-lifetime"=>4000, "subnet4"=>[{"subnet"=>"192.168.0.0/24", "reservations"=>[{"hw-address"=>"14:18:77:ab:cd:ef", "ip-address"=>"192.168.0.1", "hostname"=>"vmhost1.example.com", "option-data"=>[{"code"=>15, "name"=>"domain-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"example.com"}]}, {"hw-address"=>"52:54:00:12:34:56", "ip-address"=>"192.168.0.2", "hostname"=>"testvm.example.com", "option-data"=>[{"code"=>15, "name"=>"domain-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"example.com"}]}], "option-data"=>[{"code"=>3, "name"=>"routers", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>6, "name"=>"domain-name-servers", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>66, "name"=>"tftp-server-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>67, "name"=>"boot-file-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"pxelinux.0"}], "next-server"=>"192.168.0.1"}]}})
+    it 'configures a server' do
+      server_config =
+      {
+        'Dhcp4' => {
+          'interfaces-config' => {
+            'interfaces' => lambda { |value|
+                              value.is_a?(Array) &&
+                              value.all? { |v| v.is_a?(String) }
+                            }
+          },
+          'lease-database' => {
+            'type' => 'memfile'
+          },
+          'valid-lifetime' => Integer,
+          'subnet4' => Array
+        }
+      }
 
+      expect(@tool.kea_config).to have_structure(server_config)
+    end
+
+    it 'configures a subnet' do
+      subnet_config =
+      {
+        'subnet' => String,
+        'reservations' => Array,
+        'option-data' => Array,
+        'next-server' => /\d{1,3}\.\d{1,3}.\d{1,3}.\d{1,3}/
+      }
+
+      expect(@tool.kea_config['Dhcp4']['subnet4']).to have(1).items
+      expect(@tool.kea_config['Dhcp4']['subnet4'].first).to have_structure(subnet_config)
+    end
+
+    it 'reserves vmhost1.example.com' do
+      vmhost1_config =
+      {
+        'hw-address' => '14:18:77:ab:cd:ef',
+        'ip-address' => '192.168.0.1',
+        'hostname' => 'vmhost1.example.com',
+        'option-data' => [
+          {
+            'code' => 15,
+            'name' => 'domain-name',
+            'space' => 'dhcp4',
+            'csv-format' => true,
+            'data' => 'example.com'
+          }
+        ]
+      }
+
+      reservation = @tool.kea_config['Dhcp4']['subnet4'].first['reservations'].find { |r|
+        r['hostname'] == 'vmhost1.example.com'
+      }
+      expect(reservation).to have_structure(vmhost1_config)
+    end
+
+    context 'includes DHCP options' do
+      def check_dhcp_option(reference)
+        option = @tool.kea_config['Dhcp4']['subnet4'].first['option-data'].find { |o|
+                   o['name'] == reference['name']
+                 }
+        reference['space'] = 'dhcp4'
+        reference['csv-format'] = true
+        expect(option).to have_structure(reference)
+      end
+
+      it 'default gateway' do
+      check_dhcp_option({'code' => 3,
+                         'name' => 'routers',
+                         'data' => '192.168.0.1'})
+      end
+
+      it 'DNS resolver' do
+        check_dhcp_option({'code' => 6,
+                            'name' => 'domain-name-servers',
+                            'data' => '192.168.0.1'})
+      end
+
+      it 'TFTP server' do
+        check_dhcp_option({'code' => 66,
+                            'name' => 'tftp-server-name',
+                            'data' => '192.168.0.1'})
+      end
+
+      it 'PXE boot file name' do
+        check_dhcp_option({'code' => 67,
+                            'name' => 'boot-file-name',
+                            'data' => 'pxelinux.0'})
+      end
+    end
   end
 end

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+load "palletjack2kea"
+
+describe 'palletjack2kea' do
+  it 'generates the correct JSON tree' do
+    class PalletJack2Kea
+      def argv
+        ["-w", $EXAMPLE_WAREHOUSE,
+          "-s", "dhcp-server-example-net"]
+      end
+    end
+
+    tool = PalletJack2Kea.instance
+    tool.process
+    expect(tool.kea_config).to eql ({"Dhcp4"=>{"interfaces-config"=>{"interfaces"=>["*"]}, "lease-database"=>{"type"=>"memfile"}, "valid-lifetime"=>4000, "subnet4"=>[{"subnet"=>"192.168.0.0/24", "reservations"=>[{"hw-address"=>"14:18:77:ab:cd:ef", "ip-address"=>"192.168.0.1", "hostname"=>"vmhost1.example.com", "option-data"=>[{"code"=>15, "name"=>"domain-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"example.com"}]}, {"hw-address"=>"52:54:00:12:34:56", "ip-address"=>"192.168.0.2", "hostname"=>"testvm.example.com", "option-data"=>[{"code"=>15, "name"=>"domain-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"example.com"}]}], "option-data"=>[{"code"=>3, "name"=>"routers", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>6, "name"=>"domain-name-servers", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>66, "name"=>"tftp-server-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"192.168.0.1"}, {"code"=>67, "name"=>"boot-file-name", "space"=>"dhcp4", "csv-format"=>true, "data"=>"pxelinux.0"}], "next-server"=>"192.168.0.1"}]}})
+
+  end
+end

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'rspec_structure_matcher'
 require 'rspec/collection_matchers'
 
 load "palletjack2kea"

--- a/tools/spec/palletjack2salt_spec.rb
+++ b/tools/spec/palletjack2salt_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require 'tmpdir'
+
+load "palletjack2salt"
+
+describe 'palletjack2salt' do
+  context 'generated configuration' do
+    before :all do
+      class PalletJack2Salt
+        def argv
+          ["-w", $EXAMPLE_WAREHOUSE,
+           "-o", Dir.tmpdir] # Won't actually be written to, but needs
+                             # to exist to make the command line
+                             # option parser happy
+        end
+      end
+
+      @tool = PalletJack2Salt.instance
+      @tool.process
+    end
+
+    it 'contains configuration for some known clients' do
+      basic_structure = { 'palletjack' => Hash }
+      expect(@tool.salt_config['vmhost1.example.com']).to have_structure(basic_structure)
+      expect(@tool.salt_config['testvm.example.com']).to have_structure(basic_structure)
+    end
+
+    it 'contains configuration for all clients in the warehouse' do
+      minions = {}
+      @tool.jack.each(kind:'system') do |system|
+        minions[system['net.dns.fqdn']] = { 'palletjack' => Hash }
+      end
+      expect(@tool.salt_config).to have_structure(minions)
+    end
+
+    it 'contains network configuration' do
+      interfaces =
+      {
+        'em1' =>
+        {
+          '192.168.0.1' =>
+          {
+            'net' =>
+            {
+              'ipv4' =>
+              {
+                'gateway' => '192.168.0.1',
+                'prefixlen' => '24',
+                'cidr' => '192.168.0.0/24',
+                'address' => '192.168.0.1'
+              },
+              'layer2' =>
+              {
+                'address' => '14:18:77:ab:cd:ef',
+                'name' => 'em1'
+              }
+            }
+          }
+        }
+      }
+      expect(@tool.salt_config['vmhost1.example.com']['palletjack']['ipv4_interfaces']).to have_structure(interfaces)
+    end
+
+    it 'contains system configuration' do
+      system =
+      {
+        'os' => 'CentOS-7.2.1511-x86_64',
+        'architecture' => 'x86_64',
+        'role' => ['kvm-server', 'ssh-server'],
+        'name' => 'vmhost1'
+      }
+      expect(@tool.salt_config['vmhost1.example.com']['palletjack']['system']).to have_structure(system)
+    end
+
+    context 'contains service configuration' do
+      it 'for syslog' do
+        syslog_config =
+        [
+          {
+            'address' => 'syslog-archive.example.com',
+            'port' => 514,
+            'protocol' => 'udp'
+          },
+          {
+            'address' => 'logstash.example.com',
+            'port' => 5514,
+            'protocol' => 'tcp'
+          }
+        ]
+        0.upto(syslog_config.length) do |i|
+          expect(@tool.salt_config['vmhost1.example.com']['palletjack']['service']['syslog'][i]).to have_structure(syslog_config[i])
+        end
+      end
+
+      it 'for zabbix' do
+        zabbix_config =
+        [
+          { 'address' => 'zabbix.example.com' },
+          {
+            'address' => 'zabbix2',
+            'port' => 10051
+          }
+        ]
+        0.upto(zabbix_config.length) do |i|
+          expect(@tool.salt_config['vmhost1.example.com']['palletjack']['service']['zabbix'][i]).to have_structure(zabbix_config[i])
+        end
+      end
+    end
+  end
+end

--- a/tools/spec/palletjack2salt_spec.rb
+++ b/tools/spec/palletjack2salt_spec.rb
@@ -5,17 +5,14 @@ load "palletjack2salt"
 
 describe 'palletjack2salt' do
   context 'generated configuration' do
-    before :all do
-      class PalletJack2Salt
-        def argv
-          ["-w", $EXAMPLE_WAREHOUSE,
-           "-o", Dir.tmpdir] # Won't actually be written to, but needs
-                             # to exist to make the command line
-                             # option parser happy
-        end
-      end
-
+    before :each do
       @tool = PalletJack2Salt.instance
+      allow(@tool).to receive(:argv).and_return(
+        ["-w", $EXAMPLE_WAREHOUSE,
+         "-o", Dir.tmpdir]) # Won't actually be written to, but needs
+                            # to exist to make the command line option
+                            # parser happy
+      @tool.setup
       @tool.process
     end
 

--- a/tools/spec/spec_helper.rb
+++ b/tools/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../../lib", __FILE__)
 $LOAD_PATH.unshift File.expand_path("../../exe", __FILE__)
 
+require 'rspec_structure_matcher'
+
 $EXAMPLE_WAREHOUSE = File.expand_path('../../../examples/warehouse', __FILE__)

--- a/tools/spec/spec_helper.rb
+++ b/tools/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path("../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../exe", __FILE__)
+
+$EXAMPLE_WAREHOUSE = File.expand_path('../../../examples/warehouse', __FILE__)


### PR DESCRIPTION
Start writing tests for the configuration generation tools.

Split the tool class `run` method into two, `process` and `output`, with tests running in between. The old code is still there, since not all tools are converted yet.

Convert `palletjack2kea` and `palletjack2salt` to this new API, and run some tests on their generated configuration. This should be enough to see if we want to keep going in this direction and convert the other tools as well.
