### PR TITLE
Standalone tool execution detection

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -63,9 +63,9 @@ class PalletJack
     #
     # Example:
     #
-    # if __FILE__ == $0
-    #   MyTool.run
-    # end
+    #   if MyTool.standalone?(__FILE__)
+    #     MyTool.run
+    #   end
 
     # v0.1.0 API, retained until all tools have been updated to
     # v0.1.1:
@@ -95,6 +95,13 @@ class PalletJack
         instance.process
         instance.output
       end
+    end
+
+    # Predicate for detecting if we are being invoked as a standalone
+    # tool, or loaded by e.g. a test framework.
+
+    def self.standalone?(file)
+      File::basename(file) == File::basename($0)
     end
 
     # Generate data in an internal format, saving it for later testing

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,5 @@
 require 'kvdag'
 
 class PalletJack < KVDAG
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -103,6 +103,6 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
   end
 end
 
-if __FILE__ == $0
+if PalletJack2Kea.standalone?(__FILE__)
   PalletJack2Kea.run
 end

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -68,6 +68,6 @@ Write Salt pillar data from a Palletjack warehouse, one YAML file per system"
   end
 end
 
-if __FILE__ == $0
+if PalletJack2Salt.standalone?(__FILE__)
   PalletJack2Salt.run
 end


### PR DESCRIPTION
Try to detect if a tool is being run as a standalone tool or loaded by e.g. a test framework. Just using `__FILE__ == $0` will not work, because RubyGems will install a wrapper to handle multiversion installations.