### PR TITLE
Revert to modern versions of dev tools

### DIFF
--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rugged', '~> 0.24'
   spec.add_runtime_dependency 'kvdag', '~> 0.1.3'
 
-  spec.add_development_dependency "bundler", "~> 1.7.8"
-  spec.add_development_dependency "rake", "~> 0.9.6"
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.has_rdoc	= true

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dns-zone', '~> 0.3'
   spec.add_runtime_dependency 'ruby-ip', '~> 0.9'
 
-  spec.add_development_dependency "bundler", "~> 1.7.8"
-  spec.add_development_dependency "rake", "~> 0.9.6"
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec_structure_matcher", "~> 0.0.6"
   spec.add_development_dependency "rspec-collection_matchers", "~> 1.1.2"


### PR DESCRIPTION
The versions provided by CentOS are too outdated to be useful, so use current versions from rubygems instead.