### PR TITLE
Finish transition from PalletJack::Tool API v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,11 @@ We are happy to accept contributions in the form of issues and pull requests on 
     - If your code needs larger chunks of static data to work, please provide it in a separate directory under `examples/`. See e.g. [the `examples/pxelinux/` tree](https://github.com/saab-simc-admin/palletjack/tree/master/examples/pxelinux), which contains files required to make sense of the output from `palletjack2pxelinux`.
 
   - Write your commit messages in the usual Git style: a short summary in the first line, then paragraphs of explanatory text, line wrapped.
+
+- Test your code.
+
+  - Tests shall be written in [RSpec](http://rspec.info/).
+
+  - Library code shall have unit tests.
+
+  - Tools shall have integration and end-to-end tests.

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -49,8 +49,6 @@ class PalletJack
   class Tool
     include Singleton
 
-    # v0.1.1 API:
-    #
     # :call-seq:
     # run
     #
@@ -67,34 +65,10 @@ class PalletJack
     #     MyTool.run
     #   end
 
-    # v0.1.0 API, retained until all tools have been updated to
-    # v0.1.1:
-    #
-    # :call-seq:
-    # run &block
-    #
-    # Run the +block+ given in the context of the tool singleton instance
-    # as convenience for simple tools.
-    #
-    # More complex tools probably want to override parse_options to
-    # add option parsing, and split functionality into multiple methods.
-    #
-    # Example:
-    #
-    #   MyTool.run { jack.each(kind:'system') {|sys| puts sys.to_yaml } }
-
     def self.run(&block)
-      if block
-        # v0.1.0 API. When all tools have been ported, remove this and
-        # bump the minor version number.
-        instance.setup
-        instance.instance_eval(&block)
-      else
-        # v0.1.1 API
-        instance.setup
-        instance.process
-        instance.output
-      end
+      instance.setup
+      instance.process
+      instance.output
     end
 
     # Predicate for detecting if we are being invoked as a standalone

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,5 @@
 require 'kvdag'
 
 class PalletJack < KVDAG
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/spec/palletjack-tool_spec.rb
+++ b/spec/palletjack-tool_spec.rb
@@ -12,18 +12,14 @@ describe PalletJack::Tool do
       allow(PalletJack::Tool.instance).to receive(:argv).and_return([])
     end
 
-    it 'can run a block in its instance context' do
-      expect(PalletJack::Tool.run { self.class }).to be PalletJack::Tool
-    end
-
-    it 'keeps state between invocations' do
-      PalletJack::Tool.run { @__rspec__remember_me = true }
-      expect(PalletJack::Tool.run { @__rspec__remember_me }).to be true
-    end
-
     it 'requires a warehouse' do
+      class TestTool < PalletJack::Tool
+        def process
+          jack
+        end
+      end
       allow($stderr).to receive :write # Drop stderr output from #abort
-      expect{ PalletJack::Tool.run { jack } }.to raise_error SystemExit
+      expect{ TestTool.run }.to raise_error SystemExit
     end
   end
 

--- a/tools/exe/create_domain
+++ b/tools/exe/create_domain
@@ -23,30 +23,32 @@ Create domain and ipv4_network objects in a warehouse"
     required_option :domain
     required_option :network
   end
+
+  def output
+    # Create the IPv4 Network object
+
+    pallet_dir 'ipv4_network', :network
+    pallet_box 'ipv4_network', :network, 'dhcp' do
+      { net:{ dhcp:{ 'tftp-server' => '', 'boot-file' => '' } } }
+    end
+    pallet_box 'ipv4_network', :network, 'identity' do
+      { net:{ ipv4:{ gateway:'' },
+          dns:{ resolver:[''] } } }
+    end
+
+    # Create the DNS domain object
+
+    pallet_dir 'domain', :domain
+    pallet_box 'domain', :domain, 'dns' do
+      { net:{ dns:{ ns:[''], 'soa-ns' => '', 'soa-contact' => '' } } }
+    end
+    pallet_box 'domain', :domain, 'services' do
+      { net:{ service:{ syslog:[{address:'', port:'514', protocol:'udp' } ] } } }
+    end
+    pallet_links 'domain', :domain, 'ipv4_network' => ['ipv4_network', :network]
+  end
 end
 
-CreateDomain.run do
-
-  # Create the IPv4 Network object
-
-  pallet_dir 'ipv4_network', :network
-  pallet_box 'ipv4_network', :network, 'dhcp' do
-    { net:{ dhcp:{ 'tftp-server' => '', 'boot-file' => '' } } }
-  end
-  pallet_box 'ipv4_network', :network, 'identity' do
-    { net:{ ipv4:{ gateway:'' },
-            dns:{ resolver:[''] } } }
-  end
-
-  # Create the DNS domain object
-
-  pallet_dir 'domain', :domain
-  pallet_box 'domain', :domain, 'dns' do
-    { net:{ dns:{ ns:[''], 'soa-ns' => '', 'soa-contact' => '' } } }
-  end
-  pallet_box 'domain', :domain, 'services' do
-    { net:{ service:{ syslog:[{address:'', port:'514', protocol:'udp' } ] } } }
-  end
-  pallet_links 'domain', :domain, 'ipv4_network' => ['ipv4_network', :network]
-
+if CreateDomain.standalone?(__FILE__)
+  CreateDomain.run
 end

--- a/tools/exe/create_ipv4_interface
+++ b/tools/exe/create_ipv4_interface
@@ -29,23 +29,26 @@ Create phy_nic and ipv4_interface objects in a warehouse"
     required_option :addr
     required_option :network
   end
+
+  def output
+    # Create Physical NIC object
+
+    pallet_dir 'phy_nic', :mac
+    pallet_box 'phy_nic', :mac, 'identity' do
+      { net:{ layer2:{ name:'' } } }
+    end
+
+    # Create IPv4 Interface object
+
+    pallet_dir 'ipv4_interface', :addr
+    pallet_links 'ipv4_interface', :addr,
+      'ipv4_network' => ['ipv4_network', :network],
+      'domain' => ['domain', :domain],
+      'phy_nic' => ['phy_nic', :mac],
+      'system' => ['system', :system]
+  end
 end
 
-CreateIPv4Interface.run do
-
-  # Create Physical NIC object
-
-  pallet_dir 'phy_nic', :mac
-  pallet_box 'phy_nic', :mac, 'identity' do
-    { net:{ layer2:{ name:'' } } }
-  end
-
-  # Create IPv4 Interface object
-
-  pallet_dir 'ipv4_interface', :addr
-  pallet_links 'ipv4_interface', :addr,
-    'ipv4_network' => ['ipv4_network', :network],
-    'domain' => ['domain', :domain],
-    'phy_nic' => ['phy_nic', :mac],
-    'system' => ['system', :system]
+if CreateIPv4Interface.standalone?(__FILE__)
+  CreateIPv4Interface.run
 end

--- a/tools/exe/create_system
+++ b/tools/exe/create_system
@@ -26,20 +26,24 @@ Create system objects in a warehouse"
     required_option :os, :netinstall
     exclusive_options :os, :netinstall
   end
+
+  def output
+    pallet_dir 'system', :system
+    pallet_box 'system', :system, 'role' do
+      { system:{ role:[ '' ] } }
+    end
+    pallet_links 'system', :system, 'domain' => ['domain', :domain]
+    pallet_links 'system', :system,
+      if options[:os]
+        { 'os' => ['os', :os], 'netinstall' => [] }
+      elsif options[:netinstall]
+        { 'os' => [], 'netinstall' => ['netinstall', :netinstall] }
+      else
+        abort('Both --os and --netinstall were nil; should not happen!')
+      end
+  end
 end
 
-CreateSystem.run do
-  pallet_dir 'system', :system
-  pallet_box 'system', :system, 'role' do
-    { system:{ role:[ '' ] } }
-  end
-  pallet_links 'system', :system, 'domain' => ['domain', :domain]
-  pallet_links 'system', :system,
-    if options[:os]
-      { 'os' => ['os', :os], 'netinstall' => [] }
-    elsif options[:netinstall]
-      { 'os' => [], 'netinstall' => ['netinstall', :netinstall] }
-    else
-      abort('Both --os and --netinstall were nil; should not happen!')
-    end
+if CreateSystem.standalone?(__FILE__)
+  CreateSystem.run
 end

--- a/tools/exe/dump_pallet
+++ b/tools/exe/dump_pallet
@@ -35,16 +35,20 @@ pallets of the specified type."
       puts p.to_yaml
     end
   end
-end
 
-DumpPallet.run do
-  # Since the Tool framework uses destructive opts.parse!, all options
-  # were removed from argv, leaving just the names to search for.
-  if argv.empty?
-    dump_pallets jack[kind: options[:type]]
-  else
-    argv.each do |name|
-      dump_pallets jack[kind: options[:type], name: name]
+  def output
+    # Since the Tool framework uses destructive opts.parse!, all options
+    # were removed from argv, leaving just the names to search for.
+    if argv.empty?
+      dump_pallets jack[kind: options[:type]]
+    else
+      argv.each do |name|
+        dump_pallets jack[kind: options[:type], name: name]
+      end
     end
   end
+end
+
+if DumpPallet.standalone?(__FILE__)
+  DumpPallet.run
 end

--- a/tools/exe/palletjack2knot
+++ b/tools/exe/palletjack2knot
@@ -37,134 +37,164 @@ Write DNS server zone files from a Palletjack warehouse"
 }
 "
   end
-end
 
-PalletJack2Knot.run do
-  config_dir :zone_dir
+  # Generate and store forward zone data for a Pallet Jack domain
+  # object.
 
-  # Use Unix timestamp as serial number, and get it once so all zones get
-  # the same one
-  serial = Time.now.utc.to_i
+  def process_forward_zone(domain)
+    absolute_domain_name = "#{domain['net.dns.domain']}."
 
-  config_file :output, 'zones.conf' do |conf_file|
-    conf_file << git_header('palletjack2knot')
+    zone = DNS::Zone.new
 
-    jack.each(kind:'domain') do |domain|
-      absolute_domain_name = "#{domain['net.dns.domain']}."
+    zone.origin = absolute_domain_name
+    zone.ttl = domain['net.dns.ttl']
 
-      zone = DNS::Zone.new
+    zone.soa.serial = @serial
+    zone.soa.label = zone.origin
+    zone.soa.nameserver = domain['net.dns.soa-ns']
+    zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
 
-      zone.origin = absolute_domain_name
-      zone.ttl = domain['net.dns.ttl']
-
-      zone.soa.serial = serial
-      zone.soa.label = absolute_domain_name
-      zone.soa.nameserver = domain['net.dns.soa-ns']
-      zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
-
-      if domain['net.dns.mx']
-        domain['net.dns.mx'].each do |server|
-          mx = DNS::Zone::RR::MX.new
-          mx.label = absolute_domain_name
-          mx.priority = server['priority']
-          mx.exchange = server['server']
-          zone.records << mx
-        end
+    if domain['net.dns.mx']
+      domain['net.dns.mx'].each do |server|
+        mx = DNS::Zone::RR::MX.new
+        mx.label = absolute_domain_name
+        mx.priority = server['priority']
+        mx.exchange = server['server']
+        zone.records << mx
       end
+    end
 
-      domain['net.dns.ns'].each do |address|
-        ns = DNS::Zone::RR::NS.new
-        ns.label = absolute_domain_name
-        ns.nameserver = address
-        zone.records << ns
+    domain['net.dns.ns'].each do |address|
+      ns = DNS::Zone::RR::NS.new
+      ns.label = absolute_domain_name
+      ns.nameserver = address
+      zone.records << ns
+    end
+
+    if domain['net.dns.cname']
+      domain['net.dns.cname'].each do |name, target|
+        cname = DNS::Zone::RR::CNAME.new
+        cname.label = name
+        cname.domainname = target
+        zone.records << cname
       end
+    end
 
-      if domain['net.dns.cname']
-        domain['net.dns.cname'].each do |name, target|
+    if domain['net.dns.srv']
+      domain['net.dns.srv'].each do |service|
+        srv = DNS::Zone::RR::SRV.new
+        srv.label = "_#{service['service']}._#{service['protocol']}"
+        srv.target = service['target']
+        srv.port = service['port']
+        service['priority'] ||= 0
+        srv.priority = service['priority']
+        service['weight'] ||= 0
+        srv.weight = service['weight']
+        zone.records << srv
+      end
+    end
+
+    domain.children(kind:'ipv4_interface') do |interface|
+      a = DNS::Zone::RR::A.new
+      a.label = interface['net.dns.name']
+      a.address = interface['net.ipv4.address']
+      zone.records << a
+
+      if interface['net.dns.alias']
+        interface['net.dns.alias'].each do |label|
           cname = DNS::Zone::RR::CNAME.new
-          cname.label = name
-          cname.domainname = target
+          cname.label = label
+          cname.domainname = interface['net.dns.name']
           zone.records << cname
         end
       end
+    end
 
-      if domain['net.dns.srv']
-        domain['net.dns.srv'].each do |service|
-          srv = DNS::Zone::RR::SRV.new
-          srv.label = "_#{service['service']}._#{service['protocol']}"
-          srv.target = service['target']
-          srv.port = service['port']
-          service['priority'] ||= 0
-          srv.priority = service['priority']
-          service['weight'] ||= 0
-          srv.weight = service['weight']
-          zone.records << srv
-        end
-      end
+    @forward_zones[domain['net.dns.domain']] = zone
+  end
 
-      domain.children(kind:'ipv4_interface') do |interface|
-        a = DNS::Zone::RR::A.new
-        a.label = interface['net.dns.name']
-        a.address = interface['net.ipv4.address']
-        zone.records << a
 
-        if interface['net.dns.alias']
-          interface['net.dns.alias'].each do |label|
-            cname = DNS::Zone::RR::CNAME.new
-            cname.label = label
-            cname.domainname = interface['net.dns.name']
-            zone.records << cname
-          end
-        end
-      end
+  # Generate and store reverse zone data for the IPv4 network
+  # associated with a Pallet Jack domain object.
 
-      config_file :zone_dir, "#{domain['net.dns.domain']}.zone" do |zonefile|
-        zonefile << git_header('palletjack2knot', comment_char: ';')
-        zonefile << zone.dump_pretty
-      end
+  def process_reverse_zone(domain)
+    # Assume all delegations happen on octet boundaries for now.
+    # TODO: RFC 2317 classless in-addr.arpa delegation
 
-      conf_file << zone_config(domain['net.dns.domain'])
+    reverse_zone = DNS::Zone.new
 
-      next unless domain['net.ipv4.cidr']
+    absolute_reverse_zone_name = IP.new(domain['net.ipv4.cidr']).to_arpa
 
-      # Assume all delegations happen on octet boundaries for now.
-      # TODO: RFC 2317 classless in-addr.arpa delegation
+    prefix_octets, _ = domain['net.ipv4.prefixlen'].to_i.divmod(8)
+    zone_file_name = absolute_reverse_zone_name.split('.')[-(2 + prefix_octets) .. 5].join('.')
+    reverse_zone.origin = zone_file_name + '.'
 
-      reverse_zone = DNS::Zone.new
+    reverse_zone.ttl = domain['net.dns.ttl']
 
-      ip_net = IP.new(domain['net.ipv4.cidr'])
-      absolute_reverse_zone_name = ip_net.to_arpa
+    reverse_zone.soa.serial = @serial
+    reverse_zone.soa.label = reverse_zone.origin
+    reverse_zone.soa.nameserver = domain['net.dns.soa-ns']
+    reverse_zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
 
-      prefix_octets, _ = domain['net.ipv4.prefixlen'].to_i.divmod(8)
-      reverse_zone.origin = absolute_reverse_zone_name.split('.')[-(2 + prefix_octets) .. 5].join('.')
+    domain['net.dns.ns'].each do |address|
+      ns = DNS::Zone::RR::NS.new
+      ns.label = reverse_zone.origin
+      ns.nameserver = address
+      reverse_zone.records << ns
+    end
 
-      reverse_zone.ttl = domain['net.dns.ttl']
+    domain.children(kind:'ipv4_interface') do |interface|
+      ptr = DNS::Zone::RR::PTR.new
+      ptr.label = IP.new(interface['net.ipv4.address']).to_arpa
+      ptr.name = "#{interface['net.dns.fqdn']}."
+      reverse_zone.records << ptr
+    end
 
-      reverse_zone.soa.serial = serial
-      reverse_zone.soa.label = "#{reverse_zone.origin}."
-      reverse_zone.soa.nameserver = domain['net.dns.soa-ns']
-      reverse_zone.soa.email = "#{domain['net.dns.soa-contact']}.".sub('@', '.')
+    @reverse_zones[zone_file_name] = reverse_zone
+  end
 
-      domain['net.dns.ns'].each do |address|
-        ns = DNS::Zone::RR::NS.new
-        ns.label = "#{reverse_zone.origin}."
-        ns.nameserver = address
-        reverse_zone.records << ns
-      end
 
-      domain.children(kind:'ipv4_interface') do |interface|
-        ptr = DNS::Zone::RR::PTR.new
-        ptr.label = IP.new(interface['net.ipv4.address']).to_arpa
-        ptr.name = "#{interface['net.dns.fqdn']}."
-        reverse_zone.records << ptr
-      end
+  def process
+    config_dir :zone_dir
 
-      config_file :zone_dir, "#{reverse_zone.origin}.zone" do |zonefile|
-        zonefile << git_header('palletjack2knot', comment_char: ';')
-        zonefile << reverse_zone.dump_pretty
-      end
+    # Temporary storage in hashes of "domain name" => DNS::Zone object
+    @forward_zones = {}
+    @reverse_zones = {}
 
-      conf_file << zone_config(reverse_zone.origin)
+    # Use Unix timestamp as serial number, and get it once so all zones get
+    # the same one
+    @serial = Time.now.utc.to_i
+
+    jack.each(kind:'domain') do |domain|
+      process_forward_zone(domain)
+      process_reverse_zone(domain)
     end
   end
+
+
+  def output
+    config_file :output, 'zones.conf' do |conf_file|
+      conf_file << git_header('palletjack2knot')
+
+      @forward_zones.each do |domain, zone|
+        config_file :zone_dir, "#{domain}.zone" do |zonefile|
+          zonefile << git_header('palletjack2knot', comment_char: ';')
+          zonefile << zone.dump_pretty
+          conf_file << zone_config(domain)
+        end
+      end
+
+      @reverse_zones.each do |domain, zone|
+        config_file :zone_dir, "#{domain}.zone" do |zonefile|
+          zonefile << git_header('palletjack2knot', comment_char: ';')
+          zonefile << zone.dump_pretty
+          conf_file << zone_config(domain)
+        end
+      end
+    end
+  end
+end
+
+if PalletJack2Knot.standalone?(__FILE__)
+  PalletJack2Knot.run
 end

--- a/tools/exe/palletjack2pxelinux
+++ b/tools/exe/palletjack2pxelinux
@@ -142,15 +142,14 @@ LABEL MainMenu
 "
     end
   end
-end
 
-PalletJack2PXELinux.run do
-  config_dir :output, 'config'
-  config_dir :output, 'pxelinux.cfg'
+  def output
+    config_dir :output, 'config'
+    config_dir :output, 'pxelinux.cfg'
 
-  config_file :output, 'config', 'linux.menu' do |menufile|
-    menufile << git_header('palletjack2pxelinux')
-    menufile << "
+    config_file :output, 'config', 'linux.menu' do |menufile|
+      menufile << git_header('palletjack2pxelinux')
+      menufile << "
 UI menu.c32
 PROMPT 0
 MENU INCLUDE /config/graphics.conf
@@ -158,34 +157,39 @@ MENU INCLUDE /config/graphics.conf
 MENU TITLE Linux Installation Menu
 "
 
-    jack.each(kind:'os') do |os|
-      next unless config=os['host.pxelinux.config']
+      jack.each(kind:'os') do |os|
+        next unless config=os['host.pxelinux.config']
 
-      label=config.gsub(/-/, ' ')
+        label=config.gsub(/-/, ' ')
 
-      pxemenu_for_operating_system(os)
+        pxemenu_for_operating_system(os)
 
-      menufile << "
+        menufile << "
 LABEL #{config}
   MENU LABEL Install #{label}
   KERNEL menu.c32
   APPEND /config/#{config}.menu
 "
+      end
     end
-  end
 
-  # Generate pxe default menu links for each system
+    # Generate pxe default menu links for each system
 
-  jack.each(kind:'system') do |system|
-    system.children(kind:'ipv4_interface') do |nic|
-      if system['host.pxelinux.config']
-        menuname = "#{system['host.pxelinux.config']}.menu"
-        linkname = "01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
+    jack.each(kind:'system') do |system|
+      system.children(kind:'ipv4_interface') do |nic|
+        if system['host.pxelinux.config']
+          menuname = "#{system['host.pxelinux.config']}.menu"
+          linkname = "01-#{nic['net.layer2.address'].gsub(':', '-').downcase}"
 
-        FileUtils.ln_s(config_path('..', 'config', menuname),
-                       config_path(:output, 'pxelinux.cfg', linkname),
-                       :force => true)
+          FileUtils.ln_s(config_path('..', 'config', menuname),
+                         config_path(:output, 'pxelinux.cfg', linkname),
+                         :force => true)
+        end
       end
     end
   end
+end
+
+if PalletJack2PXELinux.standalone?(__FILE__)
+  PalletJack2PXELinux.run
 end

--- a/tools/spec/palletjack2knot_spec.rb
+++ b/tools/spec/palletjack2knot_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'rspec/collection_matchers'
+
+load 'palletjack2knot'
+
+describe 'palletjack2knot' do
+  it 'requires an output directory' do
+    @tool = PalletJack2Knot.instance
+    allow(@tool).to receive(:argv).and_return([
+      '-w', $EXAMPLE_WAREHOUSE
+    ])
+    allow($stderr).to receive(:write)
+    expect{@tool.setup}.to raise_error SystemExit
+  end
+
+  context 'generates' do
+    before :example do
+      @tool = PalletJack2Knot.instance
+      allow(@tool).to receive(:argv).and_return([
+        '-w', $EXAMPLE_WAREHOUSE,
+        '-o', Dir.tmpdir
+      ])
+      @tool.setup
+      @tool.process
+    end
+
+    it 'a forward zone' do
+      zones = @tool.instance_variable_get(:@forward_zones)
+      expect(zones).to have_at_least(1).item
+    end
+
+    it 'a reverse zone' do
+      zones = @tool.instance_variable_get(:@reverse_zones)
+      expect(zones).to have_at_least(1).item
+    end
+  end
+
+  context 'forward zone for example.com' do
+    before :example do
+      @tool = PalletJack2Knot.instance
+      allow(@tool).to receive(:argv).and_return([
+        '-w', $EXAMPLE_WAREHOUSE,
+        '-o', Dir.tmpdir
+      ])
+      @tool.setup
+      @tool.process
+      @zone = @tool.instance_variable_get(:@forward_zones)['example.com']
+    end
+
+    it 'has a reasonable timestamp' do
+      now = Time.now.utc.to_i
+      expect(now - 10 .. now + 10).to cover(@zone.soa.serial)
+    end
+
+    it 'has the correct origin' do
+      expect(@zone.origin).to eq('example.com.')
+    end
+
+    it 'has some records' do
+      expect(@zone.records).to have_at_least(2).items
+    end
+  end
+
+  context 'reverse zone for 192.168.0.0/24' do
+    before :example do
+      @tool = PalletJack2Knot.instance
+      allow(@tool).to receive(:argv).and_return([
+        '-w', $EXAMPLE_WAREHOUSE,
+        '-o', Dir.tmpdir
+      ])
+      @tool.setup
+      @tool.process
+      @zone = @tool.instance_variable_get(:@reverse_zones)['0.168.192.in-addr.arpa']
+    end
+
+    it 'has a reasonable timestamp' do
+      now = Time.now.utc.to_i
+      expect(now - 10 .. now + 10).to cover(@zone.soa.serial)
+    end
+
+    it 'has the correct origin' do
+      expect(@zone.origin).to eq('0.168.192.in-addr.arpa.')
+    end
+
+    it 'has some records' do
+      expect(@zone.records).to have_at_least(2).items
+    end
+  end
+end


### PR DESCRIPTION
- Rewrite all tools to the v0.1.1 split function API.
- Add tests for palletjack2knot. Remaining tools simply move information into or out of the warehouse, and have no significant internal state to test.
- Drop v0.1.0 API (i.e. `run { block }`).
- Bump version number to 0.2.0.