### PR TITLE
Use hierarchical names for DHCP server service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ warehouse
 │       ├── identity.yaml
 │       └── location.yaml
 ├── service
-│   ├── dhcp-server-example-net
-│   │   └── kea.yaml
+│   ├── dhcp-server
+│   │   ├── kea.yaml
+│   │   └── example-com
+│   │       └── kea.yaml
 │   └── dns-resolver
 │       └── example-com
 │           └── unbound.yaml

--- a/examples/warehouse/service/dhcp-server/example-com/kea.yaml
+++ b/examples/warehouse/service/dhcp-server/example-com/kea.yaml
@@ -1,0 +1,7 @@
+# This file provides overrides for configuration items specific to
+# this particular DHCP server instance. Other values are inherited
+# from the defaults in the parent directory.
+
+service:
+  kea_v4:
+    valid-lifetime: 4000

--- a/examples/warehouse/service/dhcp-server/kea.yaml
+++ b/examples/warehouse/service/dhcp-server/kea.yaml
@@ -6,6 +6,9 @@
 # Kea configuration structure under "Dhcp4". See the documentation at
 # <URL:http://kea.isc.org/docs/kea-guide.html#dhcp4-configuration> for
 # details.
+#
+# This file resides in the 'dhcp-server' directory and provides
+# defaults for all DHCP server instances in subdirectories.
 
 service:
   kea_v4:
@@ -14,4 +17,3 @@ service:
         - '*'
     lease-database:
       type: memfile
-    valid-lifetime: 4000

--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -35,11 +35,11 @@ Write configuration for the Kea DHCP server from a Palletjack warehouse"
   attr_reader :kea_config
 
   def process
-    @kea_config = { 'Dhcp4' => {} }
-
-    jack.each(kind:'service', name:options[:service]) do |service_config|
-      @kea_config['Dhcp4'] = service_config['service.kea_v4']
-    end
+    @kea_config = { 'Dhcp4' =>
+        jack.fetch(kind:'service',
+                   parent_name:'dhcp-server',
+                   name:options[:service])['service.kea_v4']
+      }
 
     @kea_config['Dhcp4']['subnet4'] = []
 

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -9,7 +9,7 @@ describe 'palletjack2kea' do
       @tool = PalletJack2Kea.instance
       allow(@tool).to receive(:argv).and_return(
         ["-w", $EXAMPLE_WAREHOUSE,
-         "-s", "dhcp-server-example-net"])
+         "-s", "example-com"])
       @tool.setup
       @tool.process
     end


### PR DESCRIPTION
Use the hierarchical names machinery introduced in #95 to fix the DHCP service ugliness I complained about in #97.