### PR TITLE
Fix transforms for hierarchical children

### DIFF
--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -7,8 +7,6 @@ require 'palletjack/pallet'
 
 class PalletJack < KVDAG
   attr_reader :warehouse
-  attr_reader :keytrans_reader
-  attr_reader :keytrans_writer
 
   # Create and load a PalletJack warehouse, and all its pallets
 
@@ -39,6 +37,12 @@ class PalletJack < KVDAG
         pallet(kind, pallet)
       end
     end
+
+    # Apply transforms in reverse DAG order, parents before children
+    sort.reverse.each do |pallet|
+      @keytrans_writer.transform! pallet
+    end
+
     self
   end
 

--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -48,11 +48,10 @@ class PalletJack < KVDAG
           edge(pallet, pallet:{references:{file => link_id.full_name}})
         when filestat.directory?
           child = jack.pallet(kind, File.join(name, file))
-          child.edge(self, pallet:{references:{_parent: name}})
+          child.edge(self, pallet:{references:{_parent: full_name}})
         end
       end
       merge!(pallet:{kind => name, boxes: boxes})
-      jack.keytrans_writer.transform!(self)
 
       self
     end

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,5 @@
 require 'kvdag'
 
 class PalletJack < KVDAG
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Before #95 any pallet that was loaded would make sure that all its parents were loaded before applying transform rules. With the new kind of hierarchical parent<-child relationship introduced by #95, a hierarchical parent will instead load its children before it has finished initializing itself. This causes transforms for children to fail because parent keys are not always available. 

This pull request moves the responsibility for applying transforms from `Pallet#load` to `PalletJack#load`, so that all transforms can be run, parent-before-child in reverse DAG order, after all pallets have finished loading.

Bumps version to `0.3.0` because the, now unused, `attr_reader`s for the key transformers were removed.