### PR TITLE
Trace the origin of values

### DIFF
--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -4,6 +4,7 @@ require 'kvdag'
 require 'palletjack/version'
 require 'palletjack/keytransformer'
 require 'palletjack/pallet'
+require 'traceable'
 
 class PalletJack < KVDAG
   attr_reader :warehouse
@@ -23,7 +24,7 @@ class PalletJack < KVDAG
 
   def load(warehouse)
     @warehouse = File.expand_path(warehouse)
-    key_transforms = YAML::load_file(File.join(@warehouse, "transforms.yaml"))
+    key_transforms = TraceableYAML::load_file(File.join(@warehouse, 'transforms.yaml'), 'transforms.yaml')
     @keytrans_reader = KeyTransformer::Reader.new(key_transforms)
     @keytrans_writer = KeyTransformer::Writer.new(key_transforms)
 

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -254,10 +254,10 @@ class PalletJack
               if new_value = self.send(transform.to_sym, param, context)
               then
                 new_value = TraceableString.new(new_value)
-                new_value.file = 'transformed'
-                new_value.line = 0
-                new_value.column = 0
-                new_value.byte = 0
+                new_value.file = transform.file
+                new_value.line = transform.line
+                new_value.column = transform.column
+                new_value.byte = transform.byte
                 pallet[key] = new_value
                 break
               end

--- a/lib/palletjack/keytransformer.rb
+++ b/lib/palletjack/keytransformer.rb
@@ -1,3 +1,5 @@
+require 'traceable'
+
 class PalletJack
   class KeyTransformer
     class Reader < KeyTransformer
@@ -251,6 +253,11 @@ class PalletJack
             if self.respond_to?(transform.to_sym) then
               if new_value = self.send(transform.to_sym, param, context)
               then
+                new_value = TraceableString.new(new_value)
+                new_value.file = 'transformed'
+                new_value.line = 0
+                new_value.column = 0
+                new_value.byte = 0
                 pallet[key] = new_value
                 break
               end

--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -39,16 +39,9 @@ class PalletJack < KVDAG
         filestat = File.lstat(filepath)
         case
         when (filestat.file? and file =~ /\.yaml$/)
-          File.open(filepath) do |f|
-            handler = PositionHandler.new(filepath.sub(@identity.warehouse, '')[1..-1])
-            parser = Psych::Parser.new(handler)
-            handler.parser = parser
-            parser.parse f.read
-            visitor = PositionVisitor.new
-            tree = visitor.accept(handler.root)
-            merge!(tree[0])
-            boxes << file
-          end
+          merge!(TraceableYAML::load_file(filepath,
+                   filepath.sub(@identity.warehouse, '')[1..-1]))
+          boxes << file
         when filestat.symlink?
           link = File.readlink(filepath)
           link_id = Identity.new(jack, File.expand_path(link, path))

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,5 @@
 require 'kvdag'
 
 class PalletJack < KVDAG
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -195,7 +195,13 @@ module TraceableYAML
     parser = Psych::Parser.new(handler)
     handler.parser = parser
     parser.parse doc
-    visitor = PositionVisitor.new
+    if PositionVisitor.respond_to?(:create)
+      # Ruby 2.1 and above
+      visitor = PositionVisitor.create
+    else
+      # Ruby 2.0
+      visitor = PositionVisitor.new
+    end
     tree = visitor.accept(handler.root)
     tree[0]
   end

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -87,6 +87,11 @@ class TraceableString < String
       coder.scalar += " =^.^= #{@file} (line #{@line}, column #{@column})"
     end
   end
+
+  def inspect
+    "\"%s\" (%s, line: %i, col: %i, byte: %i)" %
+      [self.to_str, @file, @line, @column, @byte]
+  end
 end
 
 # Make the nodes in Psych's YAML parse tree track their positions.

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -6,9 +6,9 @@ require 'psych'
 # Traceable can be asked for their position by calling file(), line(),
 # column() and byte().
 #
-# If the global variable $traceable_string_output_position is set,
-# to_yaml outputs position information for each atom, separated from
-# its value by the string " =^.^= ".
+# If the class attribute TraceableString.debug is set, +inspect+ and
+# +to_yaml+ output position information for each atom, in the case of
+# +to_yaml+ separated from its value by the string " =^.^= ".
 #
 # Example:
 #
@@ -42,7 +42,7 @@ require 'psych'
 #     - gazonk
 #     - foobar
 #
-#   $dump_with_position = true
+#   TraceableString.debug = true
 #   puts tree[0].to_yaml.gsub(' =^.^= ', '  # ')
 #   ---
 #   foo  # <STDIN> (line 1, column 4):
@@ -67,7 +67,7 @@ class TraceableString < String
   def encode_with(coder)
     coder.tag = nil
     coder.scalar = self.to_str
-    if $traceable_string_output_position
+    if debug?
       # LibYAML, the C YAML library which underlies Ruby's Psych
       # library, does not handle comments at all. The parser ignores
       # them and the emitter cannot write them. Thus, to output the
@@ -89,8 +89,26 @@ class TraceableString < String
   end
 
   def inspect
-    "\"%s\" (%s, line: %i, col: %i, byte: %i)" %
-      [self.to_str, @file, @line, @column, @byte]
+    if debug?
+      "\"%s\" (%s, line: %i, col: %i, byte: %i)" %
+        [self.to_str, @file, @line, @column, @byte]
+    else
+      super
+    end
+  end
+
+  def self.debug=(maybe)
+    @@debug = maybe
+  end
+
+  def self.debug
+    @@debug ||= false
+  end
+
+  private
+
+  def debug?
+    self.class.debug
   end
 end
 

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -68,12 +68,20 @@ class TraceableString < String
     coder.tag = nil
     coder.scalar = self.to_str
     if $traceable_string_output_position
+      # LibYAML, the C YAML library which underlies Ruby's Psych
+      # library, does not handle comments at all. The parser ignores
+      # them and the emitter cannot write them. Thus, to output the
+      # sourcing information in a manner that is at least semi-sane,
+      # we need to put it in the actual value, behind some sort of
+      # separator.
+      #
       # The separator needs to be representable in Latin-1, otherwise
-      # libyaml quotes it. It needs to be non-breaking, otherwise
-      # libyaml will break here to wrap at 80 characters. It cannot
-      # have any special meaning in YAML, otherwise libyaml quotes it.
-      # It shouldn't appear in real data, sine we'll need to
-      # substitute all instances of it.
+      # LibYAML quotes it. It needs to be non-breaking, otherwise
+      # LibYAML will break here to wrap at 80 characters. It cannot
+      # have any special meaning in YAML (including the quote
+      # character), otherwise LibYAML quotes it. It shouldn't appear
+      # in real data, sine we'll need to substitute all instances of
+      # it.
       #
       # Also, I like cats, even ASCII ones.
       coder.scalar += " =^.^= #{@file} (line #{@line}, column #{@column})"

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -1,0 +1,155 @@
+require 'psych'
+
+# Read YAML files and remember where each value came from.
+#
+# Objects behave like normal in most respects. Objects that implement
+# Traceable can be asked for their position by calling file(), line(),
+# column() and byte().
+#
+# If the global variable $traceable_string_output_position is set,
+# to_yaml outputs position information for each atom, separated from
+# its value by the string " =^.^= ".
+#
+# Example:
+#
+#   yaml = "---
+#   foo:
+#     bar: 1
+#     baz:
+#       - gazonk
+#       - foobar"
+#   handler = PositionHandler.new("<STDIN>")
+#   parser = Psych::Parser.new(handler)
+#   handler.parser = parser
+#   parser.parse(yaml)
+#   visitor = PositionVisitor.new
+#   tree = visitor.accept(handler.root)
+#
+#   tree[0]['foo']['bar']
+#   => "1"
+#   tree[0]['foo']['bar'].file
+#   => "<STDIN>"
+#   tree[0]['foo']['bar'].line
+#   => 3
+#   tree[0]['foo']['bar'].column
+#   => 2
+#
+#   puts tree[0].to_yaml
+#   ---
+#   foo:
+#     bar: 1
+#     baz:
+#     - gazonk
+#     - foobar
+#
+#   $dump_with_position = true
+#   puts tree[0].to_yaml.gsub(' =^.^= ', '  # ')
+#   ---
+#   foo  # <STDIN> (line 1, column 4):
+#     bar  # <STDIN> (line 2, column 6): 1  # <STDIN> (line 3, column 2)
+#     baz  # <STDIN> (line 3, column 6):
+#     - gazonk  # <STDIN> (line 5, column 4)
+#     - foobar  # <STDIN> (line 6, column 0)
+
+# Attributes required to trace the origin of a value.
+module Traceable
+  attr_accessor :file
+  attr_accessor :byte
+  attr_accessor :line
+  attr_accessor :column
+end
+
+# A string that remembers the source of its value, and can output it
+# again when serialised to YAML.
+class TraceableString < String
+  include Traceable
+
+  def encode_with(coder)
+    coder.tag = nil
+    coder.scalar = self.to_str
+    if $traceable_string_output_position
+      # The separator needs to be representable in Latin-1, otherwise
+      # libyaml quotes it. It needs to be non-breaking, otherwise
+      # libyaml will break here to wrap at 80 characters. It cannot
+      # have any special meaning in YAML, otherwise libyaml quotes it.
+      # It shouldn't appear in real data, sine we'll need to
+      # substitute all instances of it.
+      #
+      # Also, I like cats, even ASCII ones.
+      coder.scalar += " =^.^= #{@file} (line #{@line}, column #{@column})"
+    end
+  end
+end
+
+# Make the nodes in Psych's YAML parse tree track their positions.
+class Psych::Nodes::Node
+  include Traceable
+end
+
+# Extend the parser to remember the position of each object.
+class PositionHandler < Psych::TreeBuilder
+
+  # The handler needs access to the parser in order to call mark
+  attr_accessor :parser
+
+  # +filename+ is the name of the source file the YAML structure will
+  # be parsed from. It is only copied into parsed objects, not
+  # interpreted.
+  def initialize(filename)
+    super()
+    @file = filename
+  end
+
+  # Copy a parser position from a +Psych::Parser::Mark+ to a parse
+  # tree node.
+  def record_position(node, mark)
+    node.extend Traceable
+    node.file = @file
+    node.byte = mark.index
+    node.line = mark.line
+    node.column = mark.column
+    node
+  end
+
+  def start_mapping(anchor, tag, implicit, style)
+    record_position(super, parser.mark)
+  end
+
+  def start_sequence(anchor, tag, implicit, style)
+    record_position(super, parser.mark)
+  end
+
+  def scalar(value, anchor, tag, plain, quoted, style)
+    record_position(super, parser.mark)
+  end
+end
+
+# Extend the Ruby structure builder to remeber each object's position.
+class PositionVisitor < Psych::Visitors::ToRuby
+
+  # Copy a parser position from a parse tree node to a primitive
+  # object.
+  def record_position(s, o)
+    s.extend Traceable
+    s.file = o.file
+    s.byte = o.byte
+    s.line = o.line
+    s.column = o.column
+    s
+  end
+
+  def visit_Psych_Nodes_Scalar o
+    # Primitive YAML values can be either strings or integers. Ruby
+    # integers cannot be extended, so convert everything to strings
+    # before inserting position information.
+    record_position(TraceableString.new(String(super)), o)
+  end
+
+  def visit_Psych_Nodes_Sequence o
+    record_position(super, o)
+  end
+
+  def visit_Psych_Nodes_Mapping o
+    record_position(super, o)
+  end
+end

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -184,3 +184,28 @@ class PositionVisitor < Psych::Visitors::ToRuby
     record_position(super, o)
   end
 end
+
+module TraceableYAML
+
+  # Parse a YAML document from the string +doc+, tagging each value
+  # with the source +tag+, and return a Ruby object tree representing
+  # the result.
+  def self.parse(doc, tag)
+    handler = PositionHandler.new(tag)
+    parser = Psych::Parser.new(handler)
+    handler.parser = parser
+    parser.parse doc
+    visitor = PositionVisitor.new
+    tree = visitor.accept(handler.root)
+    tree[0]
+  end
+
+  # Load a YAML document from the file +path+, tagging each value with
+  # the source +tag+, and return a Ruby object tree representing the
+  # result.
+  def self.load_file(path, tag)
+    File.open(path) do |f|
+      parse(f.read, tag)
+    end
+  end
+end

--- a/spec/palletjack-pallet_spec.rb
+++ b/spec/palletjack-pallet_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 require 'rspec_structure_matcher'
+require 'traceable'
 
 describe PalletJack::Pallet do
   before :context do
     @jack = PalletJack.load($EXAMPLE_WAREHOUSE)
   end
-  
+
   it 'can load contents of a pallet' do
     expect {
       path = File.join('domain', 'example.com')
@@ -13,7 +14,7 @@ describe PalletJack::Pallet do
       PalletJack::Pallet.load(@jack, identity)
     }.not_to raise_error
   end
-  
+
   it 'cannot load contents of a non-existent pallet' do
     expect {
       path = File.join('__invalid__', '__no_such__')
@@ -21,25 +22,32 @@ describe PalletJack::Pallet do
       PalletJack::Pallet.load(@jack, identity)
     }.to raise_error Errno::ENOENT
   end
-  
+
   context 'a loaded pallet' do
     before :context do
       path = File.join('domain', 'example.com')
       identity = PalletJack::Pallet::Identity.new(@jack, path)
       @pallet = PalletJack::Pallet.load(@jack, identity)
     end
-    
+
     it 'has a kind' do
       expect(@pallet.kind).to match 'domain'
     end
-    
+
     it 'has a name' do
       expect(@pallet.name).to match 'example.com'
     end
-    
+
     it 'serializes into YAML of its key contents' do
       pallet_hash = @pallet.to_hash
-      yaml_hash = YAML::load(@pallet.to_yaml)
+
+      handler = PositionHandler.new('@pallet')
+      parser = Psych::Parser.new(handler)
+      handler.parser = parser
+      parser.parse(@pallet.to_yaml)
+      visitor = PositionVisitor.new
+      yaml_hash = visitor.accept(handler.root)[0]
+
       expect(yaml_hash).to have_structure pallet_hash
     end
   end

--- a/spec/palletjack-pallet_spec.rb
+++ b/spec/palletjack-pallet_spec.rb
@@ -40,13 +40,7 @@ describe PalletJack::Pallet do
 
     it 'serializes into YAML of its key contents' do
       pallet_hash = @pallet.to_hash
-
-      handler = PositionHandler.new('@pallet')
-      parser = Psych::Parser.new(handler)
-      handler.parser = parser
-      parser.parse(@pallet.to_yaml)
-      visitor = PositionVisitor.new
-      yaml_hash = visitor.accept(handler.root)[0]
+      yaml_hash = TraceableYAML::parse(@pallet.to_yaml, @pallet.name)
 
       expect(yaml_hash).to have_structure pallet_hash
     end

--- a/spec/palletjack-pallet_spec.rb
+++ b/spec/palletjack-pallet_spec.rb
@@ -3,7 +3,7 @@ require 'rspec_structure_matcher'
 require 'traceable'
 
 describe PalletJack::Pallet do
-  before :context do
+  before :example do
     @jack = PalletJack.load($EXAMPLE_WAREHOUSE)
   end
 
@@ -25,6 +25,7 @@ describe PalletJack::Pallet do
 
   context 'a loaded pallet' do
     before :context do
+      @jack = PalletJack.load($EXAMPLE_WAREHOUSE)
       path = File.join('domain', 'example.com')
       identity = PalletJack::Pallet::Identity.new(@jack, path)
       @pallet = PalletJack::Pallet.load(@jack, identity)
@@ -43,6 +44,33 @@ describe PalletJack::Pallet do
       yaml_hash = TraceableYAML::parse(@pallet.to_yaml, @pallet.name)
 
       expect(yaml_hash).to have_structure pallet_hash
+    end
+  end
+
+  context 'value sources' do
+    before :context do
+      @jack = PalletJack.load($EXAMPLE_WAREHOUSE)
+      @pallet = @jack.fetch(kind:'domain', name:'example.com')
+    end
+
+    it 'exist for loaded values' do
+      expect(@pallet['net.dns.soa-ns'].file).to eq "domain/example.com/dns.yaml"
+      expect(@pallet['net.dns.soa-ns'].line).to be_an Integer
+      expect(@pallet['net.dns.soa-ns'].line).not_to be 0
+      expect(@pallet['net.dns.soa-ns'].column).to be_an Integer
+      expect(@pallet['net.dns.soa-ns'].column).not_to be 0
+      expect(@pallet['net.dns.soa-ns'].byte).to be_an Integer
+      expect(@pallet['net.dns.soa-ns'].byte).not_to be 0
+    end
+
+    it 'exist for transformed values' do
+      expect(@pallet['net.dns.domain'].file).to eq "transforms.yaml"
+      expect(@pallet['net.dns.domain'].line).to be_an Integer
+      expect(@pallet['net.dns.domain'].line).not_to be 0
+      expect(@pallet['net.dns.domain'].column).to be_an Integer
+      expect(@pallet['net.dns.domain'].column).not_to be 0
+      expect(@pallet['net.dns.domain'].byte).to be_an Integer
+      expect(@pallet['net.dns.domain'].byte).not_to be 0
     end
   end
 end

--- a/spec/palletjack-tool_spec.rb
+++ b/spec/palletjack-tool_spec.rb
@@ -37,7 +37,7 @@ describe PalletJack::Tool do
     it 'can load a config pallet from a warehouse' do
       expect(@tool.config.kind).to match /^_config$/
       expect(@tool.config.name).to match TestTool.to_s
-      expect(@tool.config['rspec.test_ok']).to be true
+      expect(@tool.config['rspec.test_ok']).to eq "true"
     end
   end
 end

--- a/tools/exe/dump_pallet
+++ b/tools/exe/dump_pallet
@@ -32,6 +32,11 @@ pallets of the specified type."
                                                   :leaf_name
                                                 end
     }
+
+    options[:position] = false
+    parser.on('-p', '--[no-]position',
+              'output source file name and position of each value'
+              ) {|maybe| $traceable_string_output_position = maybe }
   end
 
   # Dump the yaml contents of all pallets given to STDOUT
@@ -42,7 +47,7 @@ pallets of the specified type."
     pallets.each do |p|
       puts "---"
       puts "# #{p.kind}: #{p.name}"
-      puts p.to_yaml
+      puts p.to_yaml.gsub(' =^.^= ', '   # ')
     end
   end
 

--- a/tools/exe/dump_pallet
+++ b/tools/exe/dump_pallet
@@ -36,7 +36,7 @@ pallets of the specified type."
     options[:position] = false
     parser.on('-p', '--[no-]position',
               'output source file name and position of each value'
-              ) {|maybe| $traceable_string_output_position = maybe }
+              ) {|maybe| TraceableString.debug = maybe }
   end
 
   # Dump the yaml contents of all pallets given to STDOUT

--- a/tools/spec/palletjack2kea_spec.rb
+++ b/tools/spec/palletjack2kea_spec.rb
@@ -27,7 +27,10 @@ describe 'palletjack2kea' do
           'lease-database' => {
             'type' => 'memfile'
           },
-          'valid-lifetime' => Integer,
+          'valid-lifetime' => lambda { |value|
+                              value.is_a?(String) &&
+                              value.to_i != 0
+                            },
           'subnet4' => Array
         }
       }

--- a/tools/spec/palletjack2salt_spec.rb
+++ b/tools/spec/palletjack2salt_spec.rb
@@ -108,12 +108,12 @@ describe 'palletjack2salt' do
         [
           {
             'address' => 'syslog-archive.example.com',
-            'port' => 514,
+            'port' => '514',
             'protocol' => 'udp'
           },
           {
             'address' => 'logstash.example.com',
-            'port' => 5514,
+            'port' => '5514',
             'protocol' => 'tcp'
           }
         ]
@@ -128,7 +128,7 @@ describe 'palletjack2salt' do
           { 'address' => 'zabbix.example.com' },
           {
             'address' => 'zabbix2',
-            'port' => 10051
+            'port' => '10051'
           }
         ]
         0.upto(zabbix_config.length) do |i|


### PR DESCRIPTION
When reading a YAML file into a hash tree, attach metadata to each object saying where in which file it came from.

Closes #36.