### PR TITLE
Fix kvdag dependency

### DIFF
--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -3,13 +3,16 @@ require 'active_support'
 require 'yaml'
 require 'kvdag'
 
+# Declare inheritance before any `require` that uses our name space
+class PalletJack < KVDAG; end
+
 # Internal dependencies
 require 'palletjack/version'
 require 'palletjack/keytransformer'
 require 'palletjack/pallet'
 require 'traceable'
 
-class PalletJack < KVDAG
+class PalletJack
   attr_reader :warehouse
 
   # Create and load a PalletJack warehouse, and all its pallets

--- a/lib/palletjack.rb
+++ b/lib/palletjack.rb
@@ -1,6 +1,9 @@
+# External dependencies
 require 'active_support'
 require 'yaml'
 require 'kvdag'
+
+# Internal dependencies
 require 'palletjack/version'
 require 'palletjack/keytransformer'
 require 'palletjack/pallet'

--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -1,7 +1,7 @@
 require 'palletjack/pallet/identity'
 require 'traceable'
 
-class PalletJack < KVDAG
+class PalletJack
   # PalletJack managed pallet of key boxes inside a warehouse.
   class Pallet < KVDAG::Vertex
 

--- a/lib/palletjack/pallet/identity.rb
+++ b/lib/palletjack/pallet/identity.rb
@@ -1,4 +1,4 @@
-class PalletJack < KVDAG
+class PalletJack
   class Pallet < KVDAG::Vertex
 
     # Represents the identity aspects of a warehouse pallet

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,5 +1,3 @@
-require 'kvdag'
-
-class PalletJack < KVDAG
-  VERSION = "0.4.1"
+class PalletJack
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
As part of #85, the `PalletJack` class was made a subclass of `KVDAG` to reduce code duplication.
This, it turns out, broke bootstrap dependencies because everything, including `palletjack/version.rb` requires `kvdag` to load.

This PR restructures the inheritance declaration for `PalletJack` to avoid this problem, and fixes #105.
