### PR TITLE
Add json dependency for palletjack-tools

### DIFF
--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 module PalletJack
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'palletjack', PalletJack::VERSION
   spec.add_runtime_dependency 'dns-zone', '~> 0.3'
   spec.add_runtime_dependency 'ruby-ip', '~> 0.9'
-  spec.add_runtime_dependency 'json', '~> 2.0'
+  spec.add_runtime_dependency 'json', '~> 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'palletjack', PalletJack::VERSION
   spec.add_runtime_dependency 'dns-zone', '~> 0.3'
   spec.add_runtime_dependency 'ruby-ip', '~> 0.9'
+  spec.add_runtime_dependency 'json', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
PalletJack2Kea requires `json`, but the runtime dependency was missing.