### PR TITLE
Hierarchy aware salt pillar generation

### DIFF
--- a/examples/warehouse/_config/PalletJack2Salt/README
+++ b/examples/warehouse/_config/PalletJack2Salt/README
@@ -1,13 +1,16 @@
 PalletJack2Salt Configuration
 =============================
 
-Keys under `pillar.global.each-pallet` are used to store information
-about kinds of pallets to copy into global Salt pillars under the name
-space `palletjack:global`.
+Keys under `pillar.global.*` are used to store information about which
+kinds of pallets to copy into global Salt pillars under the name space
+`palletjack:global`.
 
-Keys under `pillar.global.each-leaf-pallet` are used to store information
-about kinds of pallets without hierarchical children to copy into
-global Salt pillars under the name space `palletjack:global`.
+  - For pallet kinds listed under `.each-pallet`, the entire hierarchy
+    of pallets is copied.
+
+  - For pallet kinds listed under `.each-leaf-pallet`, only leaves in
+    the hierarchy are copied, i.e. pallets without children of their
+    own kind.
 
 Keys under `pillar.per-minion.each-subtree` are used to store information
 about which key subtrees to copy from each `system` object into

--- a/examples/warehouse/_config/PalletJack2Salt/README
+++ b/examples/warehouse/_config/PalletJack2Salt/README
@@ -5,6 +5,10 @@ Keys under `pillar.global.each-pallet` are used to store information
 about kinds of pallets to copy into global Salt pillars under the name
 space `palletjack:global`.
 
+Keys under `pillar.global.each-leaf-pallet` are used to store information
+about kinds of pallets without hierarchical children to copy into
+global Salt pillars under the name space `palletjack:global`.
+
 Keys under `pillar.per-minion.each-subtree` are used to store information
 about which key subtrees to copy from each `system` object into
 per-minion Salt pillars under the name space `palletjack`.
@@ -22,6 +26,8 @@ global.yaml:
     global:
       each-pallet:
         <dst key>: <pallet kind>  # Copy pallets to pillars.
+      each-leaf-pallet:
+        <dst key>: <pallet kind>  # Copy leaf pallets to pillars.
 
 per-minion.yaml
   pillar:

--- a/examples/warehouse/_config/PalletJack2Salt/global.yaml
+++ b/examples/warehouse/_config/PalletJack2Salt/global.yaml
@@ -2,5 +2,6 @@
 pillar:
   global:
     each-pallet:
-      netinstall: netinstall
       os: os
+    each-leaf-pallet:
+      netinstall: netinstall

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 module PalletJack
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -59,7 +59,7 @@ Write Salt pillar data from a Palletjack warehouse."
   def process_global_pillar
     result = {}
 
-    config['pillar.global.each-pallet'].each do |dst_key, kind|
+    (config['pillar.global.each-pallet'] || []).each do |dst_key, kind|
       result[dst_key] ||= {}
 
       jack.each(kind: kind) do |pallet|
@@ -67,7 +67,7 @@ Write Salt pillar data from a Palletjack warehouse."
       end
     end
 
-    config['pillar.global.each-leaf-pallet'].each do |dst_key, kind|
+    (config['pillar.global.each-leaf-pallet'] || []).each do |dst_key, kind|
       result[dst_key] ||= {}
 
       jack.each(kind: kind) do |pallet|

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -67,6 +67,16 @@ Write Salt pillar data from a Palletjack warehouse."
       end
     end
 
+    config['pillar.global.each-leaf-pallet'].each do |dst_key, kind|
+      result[dst_key] ||= {}
+
+      jack.each(kind: kind) do |pallet|
+        next unless pallet.children(kind: kind).empty?
+
+        result[dst_key][pallet.full_name] = pallet.to_hash.except('pallet')
+      end
+    end
+
     result
   end
 

--- a/tools/exe/palletjack2salt
+++ b/tools/exe/palletjack2salt
@@ -63,7 +63,7 @@ Write Salt pillar data from a Palletjack warehouse."
       result[dst_key] ||= {}
 
       jack.each(kind: kind) do |pallet|
-        result[dst_key][pallet.name] = pallet.to_hash.except('pallet')
+        result[dst_key][pallet.full_name] = pallet.to_hash.except('pallet')
       end
     end
 

--- a/tools/spec/palletjack2salt_spec.rb
+++ b/tools/spec/palletjack2salt_spec.rb
@@ -22,7 +22,7 @@ describe 'palletjack2salt' do
                                 'pxelinux' => Hash },
                     'system' => Hash }
       @tool.jack.each(kind: 'os') do |os|
-        expect(@global['os'][os.name]).to have_structure(os_pillar)
+        expect(@global['os'][os.full_name]).to have_structure(os_pillar)
       end
     end
 
@@ -31,7 +31,9 @@ describe 'palletjack2salt' do
                                 'pxelinux' => Hash },
                     'system' => Hash }
       @tool.jack.each(kind: 'netinstall') do |ni|
-        expect(@global['netinstall'][ni.name]).to have_structure(ni_pillar)
+        next unless ni.children(kind: 'netinstall').empty?
+
+        expect(@global['netinstall'][ni.full_name]).to have_structure(ni_pillar)
       end
     end
   end


### PR DESCRIPTION
`palletjack2salt` did not properly handle hierarchical pallets when generating pillars.
Use `#full_name` instead of `#name` to generate pillar keys, and add a new method to
generate pillars for leaves only, in the case when the hierarchy is used for name space only.
Fixes #113.