### PR TITLE
Fix rubocop BlockLength

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -69,7 +69,7 @@ Metrics/AbcSize:
 # Offense count: 18
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 120
+  Max: 40
   Exclude:
     - 'spec/*_spec.rb'
     - 'tools/spec/*_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,6 +70,9 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 120
+  Exclude:
+    - 'spec/*_spec.rb'
+    - 'tools/spec/*_spec.rb'
 
 # Offense count: 3
 # Configuration parameters: CountComments.


### PR DESCRIPTION
#114 broke `rake rubocop` on top level, because block length in the spec file for `palletjack2salt`.

I don't see this as a useful metric for the code quality of spec tests, so exclude all `*_spec.rb` files from the BlockLength cop, and tune the cop down for remaining offenders, to keep actual code tidy.
