### PR TITLE
Fix updated rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,5 @@ Style/IndentArray:
   EnforcedStyle: consistent
 Style/MethodName: 
   EnforcedStyle: snake_case 
+Style/SymbolArray:
+  EnforcedStyle: brackets

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ require 'rubocop'
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task :default => %i(rubocop spec)
+task :default => [:rubocop, :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ require 'rubocop'
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new(:rubocop)
 
-task :default => [:rubocop, :spec]
+task :default => %i(rubocop spec)

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -188,9 +188,9 @@ module PalletJack
     #   end
 
     def required_option(*opts)
-      @option_checks << lambda do
+      @option_checks << (lambda do
         raise ArgumentError unless opts.any? {|opt| options[opt]}
-      end
+      end)
     end
 
     # Require the presence of no more than one of the given options.
@@ -208,9 +208,9 @@ module PalletJack
     #   end
 
     def exclusive_options(*opts)
-      @option_checks << lambda do
+      @option_checks << (lambda do
         raise ArgumentError if opts.count {|opt| options[opt]} > 1
-      end
+      end)
     end
 
     # Usage information from option parser

--- a/palletjack.gemspec
+++ b/palletjack.gemspec
@@ -1,5 +1,6 @@
 #-*- ruby -*-
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'palletjack/version'

--- a/tools/palletjack-tools.gemspec
+++ b/tools/palletjack-tools.gemspec
@@ -1,5 +1,6 @@
 #-*- ruby -*-
 # coding: utf-8
+
 lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'palletjack/version'

--- a/tools/spec/palletjack2unbound_spec.rb
+++ b/tools/spec/palletjack2unbound_spec.rb
@@ -101,9 +101,9 @@ describe 'palletjack2unbound' do
       context 'outside in-addr.arpa for RFC1918 address space' do
         it 'is not declared "transparent"' do
           expect(
-            @stub_zones.select { |stub|
+            @stub_zones.reject { |stub|
               # Let's hope the examples stay in this RFC1918 space
-              stub.instance_variable_get(:@zone) !~ /\.168\.192\.in-addr\.arpa/
+              stub.instance_variable_get(:@zone) =~ /\.168\.192\.in-addr\.arpa/
             }.none? { |stub|
               instance_variable_get(:@transparent)
             }


### PR DESCRIPTION
When updated to the latest `rubocop` (0.48.0), a few new offenses were detected. This PR fixes those offenses.