### PR TITLE
Fix PalletJack::Tool#pallet_links

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -255,9 +255,7 @@ module PalletJack
     # Build a filesystem path from path components
     #
     # Symbols are looked up in the options dictionary.
-    # All other types are converted to strings. The
-    # resulting list is fed to File#join to produce a
-    # local filesystem compliant path.
+    # All components are converted to Pathname and concatenated.
     #
     # Example:
     #   parser.on(...) {|dir| options[:output] = dir }
@@ -266,14 +264,16 @@ module PalletJack
     #   config_path :output, 'subdir2'
 
     def config_path(*path)
-      File.join(path.map {|item|
-                  case item
-                  when Symbol
-                    options.fetch(item)
-                  else
-                    item.to_s
-                  end
-                })
+      path.map { |item|
+        case item
+        when Pathname
+          item
+        when Symbol
+          Pathname.new(options.fetch(item))
+        else
+          Pathname.new(item.to_s)
+        end
+      }.reduce(&:+)
     end
 
     # :call-seq:

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -378,7 +378,8 @@ module PalletJack
 
     def pallet_links(kind, name, links = {})
       links.each do |link_type, parent|
-        link_path = config_path(:warehouse, kind, name, link_type)
+        link_base = config_path(:warehouse, kind, name)
+        link_path = config_path(link_base, link_type)
 
         begin
           File.delete(link_path)
@@ -387,9 +388,9 @@ module PalletJack
         end
         unless parent.empty?
           parent_kind, parent_name = parent
-          parent_path = config_path('..', '..', parent_kind, parent_name)
+          parent_path = config_path(:warehouse, parent_kind, parent_name)
 
-          File.symlink(parent_path, link_path)
+          File.symlink(parent_path.relative_path_from(link_base), link_path)
         end
       end
     end

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -1,5 +1,6 @@
 require 'palletjack'
 require 'fileutils'
+require 'pathname'
 require 'optparse'
 require 'singleton'
 require 'rugged'

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 module PalletJack
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end


### PR DESCRIPTION
Parent symlinks used to have a hard coded relative path prefix `../..`, which does not work anymore with hierarchical names. Use `Pathname#relative_path_from` to calculate the proper relative path dynamically.

To enable this, `#config_path` has been changed to return a `Pathname` instead of `String` object. This should not break the API, because all consumers of that object already accept `Pathname` as well as `String` for path parameters (`File`, `Dir` etc), and anyone else wanting a stringy duck should be calling `#to_s` anyway.