### PR TITLE
Fix tool setup error handling

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -143,8 +143,12 @@ module PalletJack
 
       @parser.parse!(argv)
       @option_checks.each {|check| check.call }
-    rescue
-      abort(usage)
+    rescue OptionParser::ParseError => error
+      if error.args.empty?
+        abort(usage)
+      else
+        abort("#{error}\n\n#{usage}")
+      end
     end
 
     # Additional option parsing

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -137,7 +137,7 @@ module PalletJack
                  'warehouse directory', String) {|dir|
         @options[:warehouse] = dir }
       @parser.on_tail('-h', '--help', 'display usage information') {
-        raise ArgumentError }
+        raise OptionParser::ParseError }
 
       parse_options(@parser)
 
@@ -189,7 +189,7 @@ module PalletJack
 
     def required_option(*opts)
       @option_checks << (lambda do
-        raise ArgumentError unless opts.any? {|opt| options[opt]}
+        raise OptionParser::ParseError unless opts.any? {|opt| options[opt]}
       end)
     end
 
@@ -209,7 +209,7 @@ module PalletJack
 
     def exclusive_options(*opts)
       @option_checks << (lambda do
-        raise ArgumentError if opts.count {|opt| options[opt]} > 1
+        raise OptionParser::ParseError if opts.count {|opt| options[opt]} > 1
       end)
     end
 

--- a/spec/palletjack-tool_spec.rb
+++ b/spec/palletjack-tool_spec.rb
@@ -7,6 +7,16 @@ describe PalletJack::Tool do
     expect{ PalletJack::Tool.instance }.not_to raise_error
   end
 
+  it 'does not mask programming errors as usage' do
+    class BrokenTool < PalletJack::Tool
+      def parse_options(_)
+        raise RuntimeError
+      end
+    end
+
+    expect{ BrokenTool.run }.to raise_error RuntimeError
+  end
+
   context 'without a command line' do
     before :each do
       allow(PalletJack::Tool.instance).to receive(:argv).and_return([])


### PR DESCRIPTION
Current error handling during tool setup is very frustrating when developing a tool, because any error raised gets rescued into `abort(usage)`, not just tool usage errors.

Only rescue `OptionParser` related errors, and raise `OptionParser` related errors for usage errors, instead of raising generic errors. Also, prepend the actual error to the usage when the error contains useful information.