### PR TITLE
Make pallet_box useful

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 Style/IndentArray:
   EnforcedStyle: consistent
-Style/MethodName: 
-  EnforcedStyle: snake_case 
+Style/MethodName:
+  EnforcedStyle: snake_case
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,6 +323,7 @@ Style/GuardClause:
 Style/HashSyntax:
   Exclude:
     - 'Rakefile'
+    - 'exe/palletjack-pallet'
     - 'tools/Rakefile'
     - 'tools/exe/palletjack2pxelinux'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 131
+  Max: 133
 
 # Offense count: 13
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -355,7 +355,7 @@ module PalletJack
     # declaration of the box contents.
     #
     # Uses config_file to create the file, so any symbols will
-    # be looked up in the options hash.
+    # be looked up in the options hash, except for the box name.
     #
     # Example:
     #
@@ -368,7 +368,6 @@ module PalletJack
     #++
 
     def pallet_box(kind, name, box, keyvalues = {}, &block)
-      box = options[box] if box.is_a?(Symbol)
       box_path = config_path(:warehouse, kind, name, "#{box}.yaml")
       contents = KVDAG::KeyPathHashProxy.new
 

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -367,13 +367,13 @@ module PalletJack
     #        but that requires some redesign work.
     #++
 
-    def pallet_box(kind, name, box, keys = {}, &block)
+    def pallet_box(kind, name, box, keyvalues = {}, &block)
       box = options[box] if box.is_a?(Symbol)
       box_path = config_path(:warehouse, kind, name, "#{box}.yaml")
       contents = KVDAG::KeyPathHashProxy.new
 
       contents.merge! YAML::load_file(box_path) if box_path.file?
-      keys.each { |key, value| contents[key] = value }
+      keyvalues.each { |key, value| contents[key] = value }
       contents.merge! block.call if block_given?
 
       config_file box_path do |box_file|

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 module PalletJack
-  VERSION = '0.6.3'
+  VERSION = '0.6.4'
 end


### PR DESCRIPTION
The current helper method for creating key boxes in a pallet is geared towards static initialization, not updating existing boxes.

This PR extends the API with support for key path assignments, and merges new keys into existing boxes. In the future this should probably be handled automagically by `PalletJack::Pallet` when making new assignments into the key space of a pallet, but that requires some redesign work to happen.