### PR TITLE
Atomic configuration file writes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Style/MethodName:
   EnforcedStyle: snake_case
 Style/SymbolArray:
   EnforcedStyle: brackets
+Lint/HandleExceptions:
+  Exclude:
+    - 'spec/palletjack-tool_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 133
+  Max: 147
 
 # Offense count: 13
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -305,8 +305,12 @@ module PalletJack
     # config_file :option, 'fragment', 'base.ext' {|file| ... }
     # config_file ..., mode:0600 {|file| ...}
     #
-    # Creates a configuration file, with default mode:0644
-    # and calls the given block with the file as argument.
+    # Creates a temporary configuration file with an undefined name,
+    # with default mode:0644, and calls the given block with the file
+    # as argument. After the block has run, the file is atomically
+    # renamed to the given destination file name. If any errors occur,
+    # the temporary file is deleted without overwriting the
+    # destination file.
     #
     # Uses config_path to construct the path, so any symbols will
     # be looked up in the options hash.
@@ -320,9 +324,25 @@ module PalletJack
     #   end
 
     def config_file(*path, mode: 0644, &block)
-      File.open(config_path(*path),
-                File::CREAT | File::TRUNC | File::WRONLY, mode) do |file|
-        block.call(file)
+      filename = config_path(*path)
+      begin
+        temp_filename = "#{filename}.tmp.#{Process.pid}.#{rand(1000000)}"
+        temp_file = File.new(temp_filename,
+                             File::CREAT | File::EXCL | File::RDWR)
+      rescue Errno::EEXIST
+        retry
+      end
+
+      begin
+        temp_file.flock(File::LOCK_EX)
+        block.call(temp_file)
+        temp_file.flush
+        File.rename(temp_filename, filename)
+      rescue
+        File.unlink(temp_filename) rescue nil
+        raise
+      ensure
+        temp_file.close
       end
     end
 

--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -326,7 +326,7 @@ module PalletJack
     def config_file(*path, mode: 0644, &block)
       filename = config_path(*path)
       begin
-        temp_filename = "#{filename}.tmp.#{Process.pid}.#{rand(1000000)}"
+        temp_filename = "#{filename}.tmp.#{Process.pid}.#{rand(1_000_000)}"
         temp_file = File.new(temp_filename,
                              File::CREAT | File::EXCL | File::RDWR)
       rescue Errno::EEXIST

--- a/lib/palletjack/version.rb
+++ b/lib/palletjack/version.rb
@@ -1,3 +1,3 @@
 module PalletJack
-  VERSION = '0.6.4'
+  VERSION = '0.6.5'
 end

--- a/spec/palletjack-tool_spec.rb
+++ b/spec/palletjack-tool_spec.rb
@@ -60,9 +60,9 @@ describe PalletJack::Tool do
         @tool.config_file(@filename) do |file|
           @temp_name = file.path
         end
-        expect(File.exist? @filename).to be true
+        expect(File.exist?(@filename)).to be true
         File.unlink(@filename)
-        expect(File.exist? @temp_name).to be false
+        expect(File.exist?(@temp_name)).to be false
         expect(@filename.to_s).not_to eq @temp_name
       end
 
@@ -74,8 +74,8 @@ describe PalletJack::Tool do
           end
         rescue RuntimeError
         end
-        expect(File.exist? @filename).to be false
-        expect(File.exist? @temp_name).to be false
+        expect(File.exist?(@filename)).to be false
+        expect(File.exist?(@temp_name)).to be false
       end
     end
   end


### PR DESCRIPTION
Use the standard write-flush-rename trick to make creating configuration files atomic.

Closes #120.