### PR TITLE
Fix tool usage information

### DIFF
--- a/tools/exe/palletjack2kea
+++ b/tools/exe/palletjack2kea
@@ -8,7 +8,7 @@ require 'json'
 class PalletJack2Kea < PalletJack::Tool
   def parse_options(opts)
     opts.banner =
-"Usage: #{$PROGRAM_NAME} [options] <name> ...
+"Usage: #{$PROGRAM_NAME} -w <warehouse> -s <service>
 
 Write configuration for the Kea DHCP server from a Palletjack warehouse"
 

--- a/tools/exe/palletjack2unbound
+++ b/tools/exe/palletjack2unbound
@@ -94,6 +94,7 @@ into Salt state configuration for unbound.
 
 E.g.
   palletjack2unbound -w /etc/salt/respository/warehouse \\
+    -s example-com \\
     -o /etc/salt/repository/state/unbound/files"
 
     opts.on('-o DIR', '--output DIR', 'output directory', String) {|dir|


### PR DESCRIPTION
Fix usage information output by `palletjack2kea` and `palletjack2unbound`.

Closes #131.