### PR TITLE
Allow TXT records

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,7 @@ Lint/UselessAssignment:
 
 # Offense count: 16
 Metrics/AbcSize:
-  Max: 67
+  Max: 76
 
 # Offense count: 18
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -88,7 +88,7 @@ Metrics/LineLength:
 # Offense count: 26
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 59
+  Max: 67
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -79,6 +79,9 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 147
 
+Metrics/CyclomaticComplexity:
+  Max: 7
+
 # Offense count: 13
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/examples/warehouse/domain/README
+++ b/examples/warehouse/domain/README
@@ -58,7 +58,8 @@ dns.yaml:
         target: Dot-terminated FQDN or hostname of target
       - ...
     txt:
-      - label: Label to attach TXT record to
+      - label: Label to attach TXT record to (if label is absent,
+               attach it to the domain apex)
         text: Contents of TXT record
       - ...
 

--- a/examples/warehouse/domain/README
+++ b/examples/warehouse/domain/README
@@ -57,6 +57,11 @@ dns.yaml:
         weight: Defaults to 0 if not specified
         target: Dot-terminated FQDN or hostname of target
       - ...
+    txt:
+      - label: Label to attach TXT record to
+        text: Contents of TXT record
+      - ...
+
 
 services.yaml:
   net:

--- a/examples/warehouse/domain/example.com/dns.yaml
+++ b/examples/warehouse/domain/example.com/dns.yaml
@@ -24,7 +24,6 @@ net:
         port: 5269
         target: xmpp2
     txt:
-      - label: example.com.
-        text: "v=spf1 mx"
+      - text: "v=spf1 mx"
       - label: _kerberos
         text: EXAMPLE.COM

--- a/examples/warehouse/domain/example.com/dns.yaml
+++ b/examples/warehouse/domain/example.com/dns.yaml
@@ -23,3 +23,8 @@ net:
         protocol: tcp
         port: 5269
         target: xmpp2
+    txt:
+      - label: example.com.
+        text: "v=spf1 mx"
+      - label: _kerberos
+        text: EXAMPLE.COM

--- a/tools/lib/palletjack2zones.rb
+++ b/tools/lib/palletjack2zones.rb
@@ -101,7 +101,7 @@ Write DNS server zone files from a Palletjack warehouse"
     if domain['net.dns.txt']
       domain['net.dns.txt'].each do |record|
         txt = DNS::Zone::RR::TXT.new
-        txt.label = record['label']
+        txt.label = record['label'] || absolute_domain_name
         txt.text = record['text']
         zone.records << txt
       end

--- a/tools/lib/palletjack2zones.rb
+++ b/tools/lib/palletjack2zones.rb
@@ -98,6 +98,15 @@ Write DNS server zone files from a Palletjack warehouse"
       end
     end
 
+    if domain['net.dns.txt']
+      domain['net.dns.txt'].each do |record|
+        txt = DNS::Zone::RR::TXT.new
+        txt.label = record['label']
+        txt.text = record['text']
+        zone.records << txt
+      end
+    end
+
     domain.children(kind: 'ipv4_interface') do |interface|
       a = DNS::Zone::RR::A.new
       a.label = interface['net.dns.name']


### PR DESCRIPTION
Update `palletjack2zones` to allow TXT records to be specified in the warehouse and output to the zone.

Closes #130.