### PR TITLE
Check for broken symbolic links on warehouse load

### DIFF
--- a/lib/palletjack/pallet.rb
+++ b/lib/palletjack/pallet.rb
@@ -43,7 +43,11 @@ module PalletJack
           boxes << file
         when filestat.symlink?
           link = File.readlink(filepath)
-          link_id = Identity.new(jack, File.expand_path(link, path))
+          target = File.expand_path(link, path)
+          unless File.exist? target
+            raise Errno::ENOENT.new "broken symlink #{filepath} -> #{link}"
+          end
+          link_id = Identity.new(jack, target)
 
           pallet = jack.pallet(link_id.kind, link_id.full_name)
           edge(pallet, pallet: {references: {file => link_id.full_name}})


### PR DESCRIPTION
When encountering a symbolic link in the warehouse, check that the target exists before following it, and if not abort with an error naming both the source and the target.

Closes #133.

I don't think this merits a version bump or changelog entry in and of itself.