### PR TITLE
Improve YAML reader error handling

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -79,6 +79,9 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 147
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
 # Offense count: 13
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
@@ -94,6 +97,9 @@ Metrics/MethodLength:
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
   Max: 6
+
+Metrics/PerceivedComplexity:
+  Max: 8
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/lib/palletjack/errors.rb
+++ b/lib/palletjack/errors.rb
@@ -1,0 +1,14 @@
+require 'palletjack'
+
+module PalletJack
+  # Superclass for errors in Pallet Jack.
+  class Error < RuntimeError
+  end
+
+  # A semantic error in the warehouse.
+  #
+  # Syntax errors will probably throw a Psych::SyntaxError at read
+  # time instead.
+  class WarehouseError < Error
+  end
+end

--- a/lib/traceable.rb
+++ b/lib/traceable.rb
@@ -193,7 +193,7 @@ module TraceableYAML
     handler = PositionHandler.new(tag)
     parser = Psych::Parser.new(handler)
     handler.parser = parser
-    parser.parse doc
+    parser.parse(doc, tag)
     if PositionVisitor.respond_to?(:create)
       # Ruby 2.1 and above
       visitor = PositionVisitor.create


### PR DESCRIPTION
Allow boxes to be empty or YAML hashes, throw errors for everything else.

Testing warehouse error handling is difficult, since pallets cannot exist stand-alone, and it seems like overkill to include an entire (admittedly tiny) warehouse for each kind of error.

Closes #128.

This is a bug fix, and should bump the patch version.

Changelog:
* Warehouse changes:
  * Boxes should YAML hashes or empty (#128, #149)