### PR TITLE
Add standard tool argument --version

### DIFF
--- a/lib/palletjack/tool.rb
+++ b/lib/palletjack/tool.rb
@@ -137,6 +137,9 @@ module PalletJack
       @parser.on('-w DIR', '--warehouse DIR',
                  'warehouse directory', String) {|dir|
         @options[:warehouse] = dir }
+      @parser.on_tail('-V', '--version', 'display version information') {
+        puts PalletJack::VERSION
+        exit 0 }
       @parser.on_tail('-h', '--help', 'display usage information') {
         raise OptionParser::ParseError }
 


### PR DESCRIPTION
To easily check which version of the tools you are running, add a standard argument `--version`/`-V` to all tools that just prints `PalletJack::VERSION`.

This adds new user-visible functionality, and should thus increment the minor version.

Changelog:
* Tool changes:
  * New standard argument --version/-V, for printing the Pallet Jack version from a tool (#150)